### PR TITLE
parepare for other data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-exploitdb
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/mozqnet/go-exploitdb/blob/master/LICENSE)
 
-This is a tool for searching Exploits from Exploit-DB by CVE number or Exploit Database ID.
+This is a tool for searching Exploits from Exploit-DB(OffensiveSecurity) by CVE number or Exploit Database ID.
 Exploits are inserted at sqlite database(go-exploitdb) from Exploit-DB and can be searched by command line interface.
 In server mode, a simple Web API can be used.
 
@@ -101,6 +101,8 @@ $ go-exploitdb fetch
 ### Deep Fetch and Insert Exploit
 
 - This is very time consuming
+- We will further increase the mapping rate between exploit and cveID.
+- The number of exploits that can be detected remains unchanged
 
 ```bash
 $ go-exploitdb fetch -deep
@@ -126,16 +128,13 @@ searchExploit:
                 [-sparam]
 
   Command:
-        $ go-exploitdb search -stype [All/CVE/ID] -sparam [CVE-xxxx-xxxx/xxxx]
+        $ go-exploitdb search -stype [CVE/ID] -sparam [CVE-xxxx/xxxx]
 
   ex.
-  [*] If you want to search All Exploits
-        $ go-exploitdb search -stype All
-
   [*] If you want to search Exploit by CVE
         $ go-exploitdb search -stype CVE -sparam CVE-xxxx-xxxx
 
-  [*] If you want to search Exploit by EDB-ID
+  [*] If you want to search Exploit by Exploit Unique ID
         $ go-exploitdb search -stype ID -sparam xxxx
 
   -dbpath string
@@ -155,19 +154,9 @@ searchExploit:
   -quiet
         quiet mode (no output)
   -sparam string
-        All Exploits: None  |  by CVE: [CVE-xxxx-xxxx]  |  by ID: [xxxx]  (default: None)
+        All Exploits by CVE: [CVE-xxxx]  |  by ID: [xxxx]  (default: None)
   -stype string
-        All Exploits: All  |  by CVE: CVE |  by ExploitDB-ID: ID (default: All) (default "All")
-```
-
-### Search All Exploits
-
-```bash
-$ go-exploitdb search
-
-or
-
-$ go-exploitdb search -stype All
+        All Exploits by CVE ID: CVE |  by Exploit DB ID: ID (default: CVE)
 ```
 
 ### Search Exploit by CVE(ex. CVE-2009-4091)
@@ -231,92 +220,129 @@ INFO[09-30|15:05:57] Listening...                             URL=127.0.0.1:1326
 
 ### Get by cURL
 
-### Search Exploit by CVE(ex. CVE-2009-4091)
+### Search Exploit by CVE(ex. CVE-2006-2896)
 
 ```
-curl http://127.0.0.1:1326/cves/CVE-2008-6938 | jq
+$ curl http://127.0.0.1:1326/cves/CVE-2006-2896 | jq
 
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:100   433  100   433    0     0   114k      0 --:--:-- --:--:-- --:--:--  140k
-{
-  "exploit_db_id": "7109",
-  "exploit_db_url": "https://www.exploit-db.com/exploits/7109",
-  "cve_id": "CVE-2008-6938",
-  "document": {
-    "exploit_db_id": "7109",
-    "document_url": "https://github.com/offensive-security/exploitdb/exploits/windows/dos/7109.txt",
-    "description": "Pi3Web 2.0.3 - 'ISAPI' Remote Denial of Service",
-    "date": "2008-11-13T00:00:00Z",
-    "author": "Hamid Ebadi",
-    "type": "dos",
-    "palatform": "windows",
-    "port": ""
-  },
-  "shell_code": null,
-  "paper": null
-}
-```
-
-### Search Exploit by ExploitDB-ID(ex. ExploitDB-ID: 10180)
-
-```
-$ curl http://127.0.0.1:1326/edbids/10180 | jq
-
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  9844    0  9844    0     0   534k      0 --:--:-- --:--:-- --:--:--  565k
-
-
+  0     0    0     0    0     0      0      0 --:--:-- --:100   666  100   666    0     0  39340      0 --:--:-- --:--:-- --:--:-- 41625
 [
   {
-    "exploit_db_id": "10180",
-    "exploit_db_url": "https://www.exploit-db.com/exploits/10180",
-    "cve_id": "CVE-2009-4093",
-    "document": {
-      "exploit_db_id": "10180",
-      "document_url": "https://github.com/offensive-security/exploitdb/exploits/php/webapps/10180.txt",
-      "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
-      "date": "2009-11-16T00:00:00Z",
-      "author": "Amol Naik",
-      "type": "webapps",
-      "palatform": "php",
-      "port": ""
-    },
-    "shell_code": null,                                            "paper": null
-  },
-  {
-    "exploit_db_id": "10180",
-    "exploit_db_url": "https://www.exploit-db.com/exploits/10180",
-    "cve_id": "CVE-2009-4092",
-    "document": {
-      "exploit_db_id": "10180",
-      "document_url": "https://github.com/offensive-security/exploitdb/exploits/php/webapps/10180.txt",
-      "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
-      "date": "2009-11-16T00:00:00Z",
-      "author": "Amol Naik",
-      "type": "webapps",                                                "palatform": "php",
-      "port": ""
-    },
+    "ID": 325173,
+    "exploit_type": "OffensiveSecurity",
+    "exploit_unique_id": "1875",
+    "url": "https://www.exploit-db.com/exploits/1875",
+    "description": "FunkBoard CF0.71 - 'profile.php' Remote User Pass Change",
+    "cve_id": "CVE-2006-2896",
+    "offensive_security": {
+      "ID": 325173,
+      "ExploitID": 325173,
+      "exploit_unique_id": "1875",
+      "document": {
+        "OffensiveSecurityID": 325173,
+        "exploit_unique_id": "1875",
+        "document_url": "https://github.com/offensive-security/exploitdb/exploits/php/webapps/1875.html",
+        "description": "FunkBoard CF0.71 - 'profile.php' Remote User Pass Change",
+        "date": "0001-01-01T00:00:00Z",
+        "author": "ajann",
+        "type": "webapps",
+        "palatform": "php",
+        "port": ""
+      },
       "shell_code": null,
       "paper": null
-    },
+    }
+  }
+]
+```
+
+### Search Exploit by Exploit Unique ID(ex. Exploit Unique ID: 10180)
+
+```
+$ curl http://127.0.0.1:1326/id/10180 | jq
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:100  1936  100  1936    0     0  52643      0 --:--:-- --:--:-- --:--:-- 53777
+[
   {
-    "exploit_db_id": "10180",
-    "exploit_db_url": "https://www.exploit-db.com/exploits/10180",
+    "ID": 334917,
+    "exploit_type": "OffensiveSecurity",
+    "exploit_unique_id": "10180",
+    "url": "https://www.exploit-db.com/exploits/10180",
+    "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
     "cve_id": "CVE-2009-4091",
-    "document": {
-      "exploit_db_id": "10180",
-      "document_url": "https://github.com/offensive-security/exploitdb/exploits/php/webapps/10180.txt",
-      "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
-      "date": "2009-11-16T00:00:00Z",
-      "author": "Amol Naik",
-      "type": "webapps",
-      "palatform": "php",
-      "port": ""
-    },
-    "shell_code": null,
-    "paper": null
+    "offensive_security": {
+      "ID": 334917,
+      "ExploitID": 334917,
+      "exploit_unique_id": "10180",
+      "document": {
+        "OffensiveSecurityID": 334917,
+        "exploit_unique_id": "10180",
+        "document_url": "https://github.com/offensive-security/exploitdb/exploits/php/webapps/10180.txt",
+        "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
+        "date": "0001-01-01T00:00:00Z",
+        "author": "Amol Naik",
+        "type": "webapps",
+        "palatform": "php",
+        "port": ""
+      },
+      "shell_code": null,
+      "paper": null
+    }
+  },
+  {
+    "ID": 334918,
+    "exploit_type": "OffensiveSecurity",
+    "exploit_unique_id": "10180",
+    "url": "https://www.exploit-db.com/exploits/10180",
+    "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
+    "cve_id": "CVE-2009-4092",
+    "offensive_security": {
+      "ID": 334917,
+      "ExploitID": 334917,
+      "exploit_unique_id": "10180",
+      "document": {
+        "OffensiveSecurityID": 334917,
+        "exploit_unique_id": "10180",
+        "document_url": "https://github.com/offensive-security/exploitdb/exploits/php/webapps/10180.txt",
+        "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
+        "date": "0001-01-01T00:00:00Z",
+        "author": "Amol Naik",
+        "type": "webapps",
+        "palatform": "php",
+        "port": ""
+      },
+      "shell_code": null,
+      "paper": null
+    }
+  },
+  {
+    "ID": 334919,
+    "exploit_type": "OffensiveSecurity",
+    "exploit_unique_id": "10180",
+    "url": "https://www.exploit-db.com/exploits/10180",
+    "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
+    "cve_id": "CVE-2009-4093",
+    "offensive_security": {
+      "ID": 334917,
+      "ExploitID": 334917,
+      "exploit_unique_id": "10180",
+      "document": {
+        "OffensiveSecurityID": 334917,
+        "exploit_unique_id": "10180",
+        "document_url": "https://github.com/offensive-security/exploitdb/exploits/php/webapps/10180.txt",
+        "description": "Simplog 0.9.3.2 - Multiple Vulnerabilities",
+        "date": "0001-01-01T00:00:00Z",
+        "author": "Amol Naik",
+        "type": "webapps",
+        "palatform": "php",
+        "port": ""
+      },
+      "shell_code": null,
+      "paper": null
+    }
   }
 ]
 ```

--- a/commands/searchExploit.go
+++ b/commands/searchExploit.go
@@ -97,15 +97,15 @@ func (p *SearchExploitCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(
 		&p.SearchType,
 		"stype",
-		"All",
-		"All Exploits: All  |  by CVE: CVE  |  by ExploitDB-ID: ID  (default: All)",
+		"CVE",
+		"All Exploits by CVE: CVE  |  by ID: ID (default: CVE)",
 	)
 
 	f.StringVar(
 		&p.SearchParam,
 		"sparam",
 		"",
-		"All Exploits: None  |  by CVE: [CVE-xxxx-xxxx]  |  by ExploitDB-ID: [xxxx]  (default: None)",
+		"All Exploits: None  |  by CVE: [CVE-xxxx]  |  by ID: [xxxx]  (default: None)",
 	)
 }
 
@@ -137,12 +137,6 @@ func (p *SearchExploitCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...inte
 
 	var results = []*models.Exploit{}
 	switch stype {
-	case "All":
-		if param != "" {
-			log15.Error("A SearchType [All] does not require parameters")
-			return subcommands.ExitFailure
-		}
-		results = driver.GetExploitAll()
 	case "CVE":
 		if !cveIDRegexp.Match([]byte(param)) {
 			log15.Error("Specify the search type [CVE] parameters in the format [CVE-xxxx-xxxx].")
@@ -156,7 +150,7 @@ func (p *SearchExploitCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...inte
 		}
 		results = driver.GetExploitByID(param)
 	default:
-		log15.Error("Specify the search type [ All / CVE / ID].")
+		log15.Error("Specify the search type [ CVE / ID].")
 		return subcommands.ExitFailure
 	}
 	fmt.Println("")
@@ -167,17 +161,28 @@ func (p *SearchExploitCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...inte
 	}
 	for _, r := range results {
 		fmt.Println("\n[*]CVE-ExploitID Reference:")
-		fmt.Printf("  CVE: %s\n  EDB-ID: %s\n", r.CveID, r.ExploitDBID)
-		fmt.Println("\n[*]Exploit Info: ")
-		fmt.Printf("  URL: %s\n", r.ExploitDBURL)
-		if r.Document != nil {
-			fmt.Printf("  Exploit Title: %s\n", r.Document.Description)
-			fmt.Printf("  Path: %s\n", r.Document.DocumentURL)
-			fmt.Printf("  File Type: %s\n", r.Document.Type)
-		}
-		if r.ShellCode != nil {
-			fmt.Println("\n[*]Exploit Code  or  Proof of Concept:")
-			fmt.Printf("%s\n", r.ShellCode.ShellCodeURL)
+		fmt.Printf("  CVE: %s\n", r.CveID)
+		fmt.Printf("  Exploit Type: %s\n", r.ExploitType)
+		fmt.Printf("  Exploit Unique ID: %s\n", r.ExploitUniqueID)
+		fmt.Printf("  URL: %s\n", r.URL)
+		fmt.Printf("  Description: %s\n", r.Description)
+		fmt.Printf("\n[*]Exploit Detail Info: ")
+		if r.OffensiveSecurity != nil {
+			fmt.Printf("\n  [*]OffensiveSecurity: ")
+			os := r.OffensiveSecurity
+			if os.Document != nil {
+				fmt.Println("\n  - Ducument:")
+				fmt.Printf("    Path: %s\n", os.Document.DocumentURL)
+				fmt.Printf("    File Type: %s\n", os.Document.Type)
+			}
+			if os.ShellCode != nil {
+				fmt.Println("\n  - Exploit Code or Proof of Concept:")
+				fmt.Printf("    %s\n", os.ShellCode.ShellCodeURL)
+			}
+			if os.Paper != nil {
+				fmt.Println("\n  - Paper:")
+				fmt.Printf("    %s\n", os.Paper.PaperURL)
+			}
 		}
 		fmt.Println("---------------------------------------")
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -59,6 +59,7 @@ func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool) (locked bool, e
 func (r *RDBDriver) MigrateDB() error {
 	if err := r.conn.AutoMigrate(
 		&models.Exploit{},
+		&models.OffensiveSecurity{},
 		&models.Document{},
 		&models.ShellCode{},
 		&models.Paper{},
@@ -68,9 +69,10 @@ func (r *RDBDriver) MigrateDB() error {
 
 	var errs gorm.Errors
 	errs = errs.Add(r.conn.Model(&models.Exploit{}).AddIndex("idx_exploit_exploit_cve_id", "cve_id").Error)
-	errs = errs.Add(r.conn.Model(&models.Document{}).AddIndex("idx_exploit_document_exploit_id", "exploit_id").Error)
-	errs = errs.Add(r.conn.Model(&models.ShellCode{}).AddIndex("idx_exploit_shell_code_exploit_id", "exploit_id").Error)
-	errs = errs.Add(r.conn.Model(&models.Paper{}).AddIndex("idx_exploit_paper_exploit_id", "exploit_id").Error)
+	errs = errs.Add(r.conn.Model(&models.OffensiveSecurity{}).AddIndex("idx_offensive_secyrity_exploit_unique_id", "exploit_unique_id").Error)
+	errs = errs.Add(r.conn.Model(&models.Document{}).AddIndex("idx_exploit_document_exploit_unique_id", "exploit_unique_id").Error)
+	errs = errs.Add(r.conn.Model(&models.ShellCode{}).AddIndex("idx_exploit_shell_code_exploit_unique_id", "exploit_unique_id").Error)
+	errs = errs.Add(r.conn.Model(&models.Paper{}).AddIndex("idx_exploit_paper_exploit_unique_id", "exploit_unique_id").Error)
 
 	for _, e := range errs {
 		if e != nil {
@@ -105,6 +107,7 @@ func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploits []models.Expl
 		errs = errs.Add(tx.Delete(models.Document{}).Error)
 		errs = errs.Add(tx.Delete(models.ShellCode{}).Error)
 		errs = errs.Add(tx.Delete(models.Paper{}).Error)
+		errs = errs.Add(tx.Delete(models.OffensiveSecurity{}).Error)
 		errs = errs.Add(tx.Delete(models.Exploit{}).Error)
 		errs = util.DeleteNil(errs)
 		if len(errs.GetErrors()) > 0 {
@@ -115,7 +118,7 @@ func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploits []models.Expl
 	var noCveIDExploitCount, cveIDExploitCount int
 	for _, exploit := range exploits {
 		if err = tx.Create(&exploit).Error; err != nil {
-			return fmt.Errorf("Failed to insert. exploitDBID: %s, err: %s", exploit.ExploitDBID, err)
+			return fmt.Errorf("Failed to insert. exploitTypeID: %s, err: %s", exploit.ExploitUniqueID, err)
 		}
 		if 0 < len(exploit.CveID) {
 			cveIDExploitCount++
@@ -131,11 +134,17 @@ func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploits []models.Expl
 }
 
 // GetExploitByID :
-func (r *RDBDriver) GetExploitByID(exploitDBID string) []*models.Exploit {
+func (r *RDBDriver) GetExploitByID(exploitUniqueID string) []*models.Exploit {
 	es := []*models.Exploit{}
-	err := r.conn.Preload("Document").Preload("ShellCode").Where(&models.Exploit{ExploitDBID: exploitDBID}).Find(&es).Error
-	if err != nil {
-		log15.Error("Failed to get exploit by CveID", "err", err)
+	var errs gorm.Errors
+	errs = errs.Add(r.conn.Where(&models.Exploit{ExploitUniqueID: exploitUniqueID}).Find(&es).Error)
+	for _, e := range es {
+		os := &models.OffensiveSecurity{}
+		errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
+		e.OffensiveSecurity = os
+	}
+	if len(errs.GetErrors()) > 0 {
+		log15.Error("Failed to get exploit by CveID", "err", errs.Error())
 	}
 	return es
 }
@@ -145,24 +154,38 @@ func (r *RDBDriver) GetExploitAll() []*models.Exploit {
 	es := []*models.Exploit{}
 	docs := []*models.Document{}
 	shells := []*models.ShellCode{}
+	papers := []*models.Paper{}
+	offensiveSecurities := []*models.OffensiveSecurity{}
 	var errs gorm.Errors
 
 	errs = errs.Add(r.conn.Find(&es).Error)
+	errs = errs.Add(r.conn.Find(&offensiveSecurities).Error)
 	errs = errs.Add(r.conn.Find(&docs).Error)
 	errs = errs.Add(r.conn.Find(&shells).Error)
+	errs = errs.Add(r.conn.Find(&papers).Error)
 	if len(errs.GetErrors()) > 0 {
 		log15.Error("Failed to delete old records", "err", errs.Error())
 	}
 
 	for _, e := range es {
-		for _, d := range docs {
-			if e.ID == d.ExploitID {
-				e.Document = d
+		for _, o := range offensiveSecurities {
+			for _, d := range docs {
+				if o.ID == d.OffensiveSecurityID {
+					o.Document = d
+				}
 			}
-		}
-		for _, s := range shells {
-			if e.ID == s.ExploitID {
-				e.ShellCode = s
+			for _, s := range shells {
+				if o.ID == s.OffensiveSecurityID {
+					o.ShellCode = s
+				}
+			}
+			for _, p := range papers {
+				if o.ID == p.OffensiveSecurityID {
+					o.Paper = p
+				}
+			}
+			if e.ID == o.ExploitID {
+				e.OffensiveSecurity = o
 			}
 		}
 	}
@@ -170,10 +193,10 @@ func (r *RDBDriver) GetExploitAll() []*models.Exploit {
 }
 
 // GetExploitMultiByID :
-func (r *RDBDriver) GetExploitMultiByID(exploitDBIDs []string) map[string][]*models.Exploit {
+func (r *RDBDriver) GetExploitMultiByID(exploitUniqueIDs []string) map[string][]*models.Exploit {
 	exploits := map[string][]*models.Exploit{}
-	for _, exploitDBID := range exploitDBIDs {
-		exploits[exploitDBID] = r.GetExploitByID(exploitDBID)
+	for _, exploitUniqueID := range exploitUniqueIDs {
+		exploits[exploitUniqueID] = r.GetExploitByID(exploitUniqueID)
 	}
 	return exploits
 }
@@ -181,9 +204,15 @@ func (r *RDBDriver) GetExploitMultiByID(exploitDBIDs []string) map[string][]*mod
 // GetExploitByCveID :
 func (r *RDBDriver) GetExploitByCveID(cveID string) []*models.Exploit {
 	es := []*models.Exploit{}
-	err := r.conn.Preload("Document").Preload("ShellCode").Where(&models.Exploit{CveID: cveID}).Find(&es).Error
-	if err != nil {
-		log15.Error("Failed to get exploit by CveID", "err", err)
+	var errs gorm.Errors
+	errs = errs.Add(r.conn.Where(&models.Exploit{CveID: cveID}).Find(&es).Error)
+	for _, e := range es {
+		os := &models.OffensiveSecurity{}
+		errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
+		e.OffensiveSecurity = os
+	}
+	if len(errs.GetErrors()) > 0 {
+		log15.Error("Failed to get exploit by CveID", "err", errs.Error())
 	}
 	return es
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -160,7 +160,7 @@ func (r *RedisDriver) InsertExploit(exploits []models.Exploit) (err error) {
 		}
 
 		if 0 < len(exploit.CveID) {
-			if result := pipe.HSet(cveIDPrefix+exploit.CveID, exploit.ExploitDBID, string(j)); result.Err() != nil {
+			if result := pipe.HSet(cveIDPrefix+exploit.CveID, exploit.ExploitUniqueID, string(j)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
 			cveIDExploitCount++
@@ -172,7 +172,7 @@ func (r *RedisDriver) InsertExploit(exploits []models.Exploit) (err error) {
 		if len(exploit.CveID) == 0 {
 			exploit.CveID = "NONE"
 		}
-		if result := pipe.HSet(exploitDBIDPrefix+exploit.ExploitDBID, exploit.CveID, string(j)); result.Err() != nil {
+		if result := pipe.HSet(exploitDBIDPrefix+exploit.ExploitUniqueID, exploit.CveID, string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet Exploit. err: %s", result.Err())
 		}
 

--- a/fetcher/exploit.go
+++ b/fetcher/exploit.go
@@ -58,24 +58,59 @@ func FetchExploitDB(deep bool) (exploits []models.Exploit, err error) {
 		cveIDs, ok := exploitCvesMap[id]
 		if ok {
 			for _, cveID := range cveIDs {
+				var description string
+				if e, ok := exploitPaperMap[id]; ok {
+					description = e.Description
+				}
+				if e, ok := exploitShellCodeMap[id]; ok {
+					description = e.Description
+				}
+				if e, ok := exploitDocMap[id]; ok {
+					description = e.Description
+				}
+				if len(description) == 0 {
+					continue
+				}
 				exploit := models.Exploit{
-					ExploitDBID:  id,
-					ExploitDBURL: "https://www.exploit-db.com/exploits/" + id,
-					CveID:        cveID,
-					Document:     exploitDocMap[id],
-					ShellCode:    exploitShellCodeMap[id],
-					Paper:        exploitPaperMap[id],
+					ExploitUniqueID: id,
+					ExploitType:     models.OffensiveSecurityType,
+					URL:             "https://www.exploit-db.com/exploits/" + id,
+					CveID:           cveID,
+					Description:     description,
+					OffensiveSecurity: &models.OffensiveSecurity{
+						ExploitUniqueID: id,
+						Document:        exploitDocMap[id],
+						ShellCode:       exploitShellCodeMap[id],
+						Paper:           exploitPaperMap[id],
+					},
 				}
 				exploits = append(exploits, exploit)
 			}
 		} else {
 			// No CveID
+			var description string
+			if e, ok := exploitPaperMap[id]; ok {
+				description = e.Description
+			}
+			if e, ok := exploitShellCodeMap[id]; ok {
+				description = e.Description
+			}
+			if e, ok := exploitDocMap[id]; ok {
+				description = e.Description
+			}
+			if len(description) == 0 {
+				continue
+			}
 			exploit := models.Exploit{
-				ExploitDBID:  id,
-				ExploitDBURL: "https://www.exploit-db.com/exploits/" + id,
-				Document:     exploitDocMap[id],
-				ShellCode:    exploitShellCodeMap[id],
-				Paper:        exploitPaperMap[id],
+				ExploitUniqueID: id,
+				ExploitType:     models.OffensiveSecurityType,
+				URL:             "https://www.exploit-db.com/exploits/" + id,
+				Description:     description,
+				OffensiveSecurity: &models.OffensiveSecurity{
+					Document:  exploitDocMap[id],
+					ShellCode: exploitShellCodeMap[id],
+					Paper:     exploitPaperMap[id],
+				},
 			}
 			exploits = append(exploits, exploit)
 		}
@@ -109,6 +144,7 @@ func FetchExploitCvesMap(deep bool) (exploitCveMap map[string][]string, err erro
 					continue
 				}
 				refType, exploitID := desc[0], desc[1]
+				// https://cve.mitre.org/data/refs/index.html
 				if refType != "EXPLOIT-DB" {
 					continue
 				}
@@ -236,7 +272,7 @@ func FetchExploitShellCodeMap() (exploitShellCodeMap map[string]*models.ShellCod
 
 	for _, shellCode := range shellCodes {
 		shellCode.ShellCodeURL = "https://github.com/offensive-security/exploitdb/" + shellCode.ShellCodeURL
-		exploitShellCodeMap[shellCode.ExploitDBID] = shellCode
+		exploitShellCodeMap[shellCode.ExploitUniqueID] = shellCode
 	}
 	return exploitShellCodeMap, nil
 }
@@ -254,7 +290,7 @@ func FetchExploitPaperMap() (exploitPaperMap map[string]*models.Paper, err error
 
 	for _, paper := range papers {
 		paper.PaperURL = "https://github.com/offensive-security/exploitdb-papers/" + paper.PaperURL
-		exploitPaperMap[paper.ExploitDBID] = paper
+		exploitPaperMap[paper.ExploitUniqueID] = paper
 	}
 	return exploitPaperMap, nil
 }
@@ -272,7 +308,7 @@ func FetchExploitDocumentMap() (exploitDocMap map[string]*models.Document, err e
 
 	for _, doc := range docs {
 		doc.DocumentURL = "https://github.com/offensive-security/exploitdb/" + doc.DocumentURL
-		exploitDocMap[doc.ExploitDBID] = doc
+		exploitDocMap[doc.ExploitUniqueID] = doc
 	}
 	return exploitDocMap, nil
 }

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -4,28 +4,46 @@ import (
 	"time"
 )
 
-var exploitDBDateFormat = "2006-01-02"
+var offensiveSecurityDateFormat = "2006-01-02"
+
+// ExploitType :
+type ExploitType string
+
+var (
+	// OffensiveSecurityType : https://www.exploit-db.com/
+	OffensiveSecurityType ExploitType = "OffensiveSecurity"
+)
 
 // Exploit :
 type Exploit struct {
-	ID           int64      `json:",omitempty"`
-	ExploitDBID  string     `json:"exploit_db_id"`
-	ExploitDBURL string     `json:"exploit_db_url"`
-	CveID        string     `json:"cve_id"`
-	Document     *Document  `json:"document"`
-	ShellCode    *ShellCode `json:"shell_code"`
-	Paper        *Paper     `json:"paper"`
+	ID                int64              `json:",omitempty"`
+	ExploitType       ExploitType        `json:"exploit_type"`
+	ExploitUniqueID   string             `json:"exploit_unique_id"`
+	URL               string             `json:"url"`
+	Description       string             `json:"description"`
+	CveID             string             `json:"cve_id"`
+	OffensiveSecurity *OffensiveSecurity `json:"offensive_security"`
+}
+
+// OffensiveSecurity : https://www.exploit-db.com/
+type OffensiveSecurity struct {
+	ID              int64      `json:",omitempty"`
+	ExploitID       int64      `sql:"type:bigint REFERENCES exploits(id)" json:",omitempty"`
+	ExploitUniqueID string     `json:"exploit_unique_id"`
+	Document        *Document  `json:"document"`
+	ShellCode       *ShellCode `json:"shell_code"`
+	Paper           *Paper     `json:"paper"`
 }
 
 // Document :
 // https://github.com/offensive-security/exploitdb/tree/master/exploits
 type Document struct {
-	ExploitID   int64         `sql:"type:bigint REFERENCES exploits(id)" json:",omitempty"`
-	ExploitDBID string        `csv:"id" json:"exploit_db_id"`
-	DocumentURL string        `csv:"file" json:"document_url"`
-	Description string        `csv:"description" json:"description"`
-	Date        ExploitDBTime `csv:"date" json:"date"`
-	Author      string        `csv:"author" json:"author"`
+	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:",omitempty"`
+	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
+	DocumentURL         string                `csv:"file" json:"document_url"`
+	Description         string                `csv:"description" json:"description"`
+	Date                OffensiveSecurityTime `csv:"date" json:"date"`
+	Author              string                `csv:"author" json:"author"`
 	// docs local remote webapps
 	Type     string `csv:"type" json:"type"`
 	Platform string `csv:"platform" json:"palatform"`
@@ -35,26 +53,26 @@ type Document struct {
 // ShellCode :
 // https://github.com/offensive-security/exploitdb/tree/master/shellcodes
 type ShellCode struct {
-	ExploitID    int64         `sql:"type:bigint REFERENCES exploits(id)" json:",omitempty"`
-	ExploitDBID  string        `csv:"id" json:"exploit_db_id"`
-	ShellCodeURL string        `csv:"file" json:"shell_code_url"`
-	Description  string        `csv:"description" json:"description"`
-	Date         ExploitDBTime `csv:"date" json:"date"`
-	Author       string        `csv:"author" json:"author"`
-	Platform     string        `csv:"platform" json:"platform"`
+	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:",omitempty"`
+	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
+	ShellCodeURL        string                `csv:"file" json:"shell_code_url"`
+	Description         string                `csv:"description" json:"description"`
+	Date                OffensiveSecurityTime `csv:"date" json:"date"`
+	Author              string                `csv:"author" json:"author"`
+	Platform            string                `csv:"platform" json:"platform"`
 }
 
 // Paper :
 // https://github.com/offensive-security/exploitdb-papers
 type Paper struct {
-	ExploitID   int64         `sql:"type:bigint REFERENCES exploits(id)" json:",omitempty"`
-	ExploitDBID string        `csv:"id" json:"exploit_db_id"`
-	PaperURL    string        `csv:"file" json:"paper_url"`
-	Description string        `csv:"description" json:"description"`
-	Date        ExploitDBTime `csv:"date" json:"date"`
-	Author      string        `csv:"author" json:"author"`
-	Platform    string        `csv:"platform" json:"platform"`
-	Language    string        `csv:"language" json:"language"`
+	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:",omitempty"`
+	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
+	PaperURL            string                `csv:"file" json:"paper_url"`
+	Description         string                `csv:"description" json:"description"`
+	Date                OffensiveSecurityTime `csv:"date" json:"date"`
+	Author              string                `csv:"author" json:"author"`
+	Platform            string                `csv:"platform" json:"platform"`
+	Language            string                `csv:"language" json:"language"`
 }
 
 // MitreXML :
@@ -80,21 +98,21 @@ type GithubJSON struct {
 	} `json:"items"`
 }
 
-// ExploitDBTime :
-type ExploitDBTime struct {
+// OffensiveSecurityTime :
+type OffensiveSecurityTime struct {
 	time.Time
 }
 
 // String :
 // You could also use the standard Stringer interface
-func (date *ExploitDBTime) String() string {
+func (date *OffensiveSecurityTime) String() string {
 	return date.String() // Redundant, just for example
 }
 
 // UnmarshalCSV :
 // Convert the CSV string as internal date
-func (date *ExploitDBTime) UnmarshalCSV(csv string) (err error) {
-	date.Time, err = time.Parse(exploitDBDateFormat, csv)
+func (date *OffensiveSecurityTime) UnmarshalCSV(csv string) (err error) {
+	date.Time, err = time.Parse(offensiveSecurityDateFormat, csv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Prepare for other data sources
- Abolished serarch all, due to high load of db
- It prevents erroneous detection of exploit deleted from OffensiveSecurity