### PR TITLE
support alpine3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV REPOSITORY github.com/prince-chrismc/go-exploitdb
 COPY . $GOPATH/src/$REPOSITORY
 RUN cd $GOPATH/src/$REPOSITORY && make install
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 MAINTAINER princechrismc
 


### PR DESCRIPTION
I update the alpine version to 3.11 in the image becaue support for alpine 3.7 has ended.
I built docker image, tested fetching in the container and got the following result,
```
❯ docker run --rm -i \
    -v $PWD:/vuls \
    -v $PWD/go-exploitdb-log:/var/log/go-exploitdb \
    exploit_test fetch exploitdb
t=2020-06-12T02:01:37+0000 lvl=info msg="Opening Database." db=sqlite3
t=2020-06-12T02:01:37+0000 lvl=info msg="Migrating DB." db=sqlite3
t=2020-06-12T02:01:37+0000 lvl=info msg="Fetching Offensive Security Exploit"
t=2020-06-12T02:01:37+0000 lvl=info msg=Fetching URL=https://cve.mitre.org/data/downloads/allitems-cvrf.xml
t=2020-06-12T02:37:59+0000 lvl=info msg=Fetching URL=https://raw.githubusercontent.com/offensive-security/exploitdb/master/files_shellcodes.csv
t=2020-06-12T02:38:00+0000 lvl=info msg=Fetching URL=https://raw.githubusercontent.com/offensive-security/exploitdb/master/files_exploits.csv
t=2020-06-12T02:38:04+0000 lvl=info msg="Offensive Security Exploit" count=45370
t=2020-06-12T02:38:04+0000 lvl=info msg="Insert Exploit into go-exploitdb." db=sqlite3
t=2020-06-12T02:38:04+0000 lvl=info msg="Inserting 45370 Exploits"
...
t=2020-06-12T02:39:22+0000 lvl=info msg="CveID Exploit Count" count=12229
```