### PR TITLE
fix volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache ca-certificates \
 
 COPY --from=builder /go/bin/go-exploitdb /usr/local/bin/
 
-VOLUME [$WORKDIR, $LOGDIR]
+VOLUME ["$WORKDIR", "$LOGDIR"]
 WORKDIR $WORKDIR
 ENV PWD $WORKDIR
 


### PR DESCRIPTION
# What did you implement:

With docker-ce 20.10.7 the container won't start anymore:
```
docker: Error response from daemon: OCI runtime create failed: invalid mount {Destination:[/vuls, Type:bind Source:/var/lib/docker/volumes/1f5bc95c42d730b2e189227ddc186134d3cc70bbbb4266b955e77182ec446063/_data Options:[rbind]}: mount destination [/vuls, not absolute: unknown.
```

Fixes # (issue): https://github.com/containerd/containerd/issues/5547

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I built the Image, starts successfully again.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

