### PR TITLE
feat(rdb): delete only records that match the ExploitType to be fetched

### DIFF
--- a/commands/fetch-awesomepoc.go
+++ b/commands/fetch-awesomepoc.go
@@ -42,7 +42,7 @@ func fetchAwesomePoc(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Awesome Poc Exploit", "count", len(exploits))
 
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
-	if err := driver.InsertExploit(exploits); err != nil {
+	if err := driver.InsertExploit(models.AwesomePocType, exploits); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}

--- a/commands/fetch-exploitdb.go
+++ b/commands/fetch-exploitdb.go
@@ -42,7 +42,7 @@ func fetchExploitDB(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Offensive Security Exploit", "count", len(exploits))
 
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
-	if err := driver.InsertExploit(exploits); err != nil {
+	if err := driver.InsertExploit(models.OffensiveSecurityType, exploits); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}

--- a/commands/fetch-githubrepos.go
+++ b/commands/fetch-githubrepos.go
@@ -42,7 +42,7 @@ func fetchGitHubRepos(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("GitHub Repos Exploit", "count", len(exploits))
 
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
-	if err := driver.InsertExploit(exploits); err != nil {
+	if err := driver.InsertExploit(models.GitHubRepositoryType, exploits); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -16,7 +16,7 @@ type DB interface {
 	GetExploitByID(string) []*models.Exploit
 	GetExploitByCveID(string) []*models.Exploit
 	GetExploitMultiByCveID([]string) map[string][]*models.Exploit
-	InsertExploit([]*models.Exploit) error
+	InsertExploit(models.ExploitType, []*models.Exploit) error
 	GetExploitAll() []*models.Exploit
 }
 

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -16,7 +16,6 @@ import (
 	// Required SQLite3.
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/vulsio/go-exploitdb/models"
-	"github.com/vulsio/go-exploitdb/util"
 )
 
 const (
@@ -95,12 +94,12 @@ func (r *RDBDriver) MigrateDB() error {
 }
 
 // InsertExploit :
-func (r *RDBDriver) InsertExploit(exploits []*models.Exploit) (err error) {
+func (r *RDBDriver) InsertExploit(exploitType models.ExploitType, exploits []*models.Exploit) (err error) {
 	log15.Info(fmt.Sprintf("Inserting %d Exploits", len(exploits)))
-	return r.deleteAndInsertExploit(r.conn, exploits)
+	return r.deleteAndInsertExploit(r.conn, exploitType, exploits)
 }
 
-func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploits []*models.Exploit) (err error) {
+func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploitType models.ExploitType, exploits []*models.Exploit) (err error) {
 	bar := pb.StartNew(len(exploits))
 	tx := conn.Begin()
 	defer func() {
@@ -111,19 +110,43 @@ func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploits []*models.Exp
 		tx.Commit()
 	}()
 
-	old := models.Exploit{}
-	result := tx.Where(&models.Exploit{}).First(&old)
-	if !result.RecordNotFound() {
-		// Delete all old records
-		var errs gorm.Errors
-		errs = errs.Add(tx.Delete(models.Document{}).Error)
-		errs = errs.Add(tx.Delete(models.ShellCode{}).Error)
-		errs = errs.Add(tx.Delete(models.OffensiveSecurity{}).Error)
-		errs = errs.Add(tx.Delete(models.GitHubRepository{}).Error)
-		errs = errs.Add(tx.Delete(models.Exploit{}).Error)
-		errs = util.DeleteNil(errs)
-		if len(errs.GetErrors()) > 0 {
-			return fmt.Errorf("Failed to delete old records. err: %s", errs.Error())
+	oldIDs := []models.Exploit{}
+	result := tx.Table("exploits").Select("id").Where("exploit_type = ?", exploitType).Find(&oldIDs)
+	if result.Error != nil && !result.RecordNotFound() {
+		return xerrors.Errorf("Failed to select old defs: %w", result.Error)
+	}
+
+	if result.RowsAffected > 0 {
+		for _, oldID := range oldIDs {
+			osIDs := []models.GitHubRepository{}
+			if err := tx.Table("offensive_securities").Select("id").Where("exploit_id = ?", oldID.ID).Find(&osIDs).Error; err != nil {
+				return xerrors.Errorf("Failed to select old OffensiveSecurity: %w", err)
+			}
+			for _, osID := range osIDs {
+				if err := tx.Where("offensive_security_id = ?", osID.ID).Delete(&models.Document{}).Error; err != nil {
+					return xerrors.Errorf("Failed to delete: %w", err)
+				}
+				if err := tx.Where("offensive_security_id = ?", osID.ID).Delete(&models.ShellCode{}).Error; err != nil {
+					return xerrors.Errorf("Failed to delete: %w", err)
+				}
+				if err := tx.Delete(&osID).Error; err != nil {
+					return xerrors.Errorf("Failed to delete: %w", err)
+				}
+			}
+
+			ghIDs := []models.GitHubRepository{}
+			if err := tx.Table("git_hub_repositories").Select("id").Where("exploit_id = ?", oldID.ID).Find(&ghIDs).Error; err != nil {
+				return xerrors.Errorf("Failed to select old GitHubRepository: %w", err)
+			}
+			for _, ghID := range ghIDs {
+				if err := tx.Delete(&ghID).Error; err != nil {
+					return xerrors.Errorf("Failed to delete: %w", err)
+				}
+			}
+
+			if err := tx.Delete(&oldID).Error; err != nil {
+				return xerrors.Errorf("Failed to delete: %w", err)
+			}
 		}
 	}
 

--- a/db/redis.go
+++ b/db/redis.go
@@ -162,7 +162,7 @@ func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) (exploitsMap map[s
 }
 
 //InsertExploit :
-func (r *RedisDriver) InsertExploit(exploits []*models.Exploit) (err error) {
+func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exploit) (err error) {
 	ctx := context.Background()
 	bar := pb.StartNew(len(exploits))
 


### PR DESCRIPTION
# What did you implement:

With this PR, only the records that match the ExploitType to be fetched will be deleted. In other words, ExploitType: OffensiveSecurity/GitHub/AwesomePoc can exist at the same time.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```console
$ go-exploitdb fetch exploitdb
$ go-exploitdb fetch awesomepoc
$ go-exploitdb fetch exploitdb

$ sqlite3 go-exploitdb.sqlite3
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.

// The data from the first fetch of exploitdb has been deleted, and the data from awesomepoc has been added to the top.
sqlite> select id, exploit_type from exploits LIMIT 5;
id|exploit_type
46788|AwesomePoc
46789|AwesomePoc
46790|AwesomePoc
46791|AwesomePoc
46792|AwesomePoc

// Of course, the data from Exploitdb is inserted at the end.
sqlite> select id, exploit_type from exploits ORDER By id desc LIMIT 5;
id|exploit_type
94397|OffensiveSecurity
94396|OffensiveSecurity
94395|OffensiveSecurity
94394|OffensiveSecurity
94393|OffensiveSecurity

$ go-exploitdb fetch githubrepos


$ sqlite3 go-exploitdb.sqlite3
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> select DISTINCT exploit_type from exploits;
exploit_type
AwesomePoc
OffensiveSecurity
GitHub
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

