### PR TITLE
fix(models): fill in OffensiveSecurityTime

### DIFF
--- a/models/exploit.go
+++ b/models/exploit.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"database/sql/driver"
 	"time"
 )
 
@@ -128,4 +129,15 @@ func (date *OffensiveSecurityTime) UnmarshalCSV(csv string) (err error) {
 		return err
 	}
 	return nil
+}
+
+// Scan :
+func (date *OffensiveSecurityTime) Scan(value interface{}) error {
+	date.Time = value.(time.Time)
+	return nil
+}
+
+// Value :
+func (date OffensiveSecurityTime) Value() (driver.Value, error) {
+	return date.Time, nil
 }


### PR DESCRIPTION
# What did you implement:
When I looked in the DB, I found that the date: OffensiveSecurityTime part was null. This has been fixed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
// upstream/master: go-exploitdb fetch exploitdb
$ sqlite3 go-exploitdb.sqlite3
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> select offensive_security_id, date from documents LIMIT 3;
offensive_security_id|date
1|
2|
3|

// PR: go-exploitdb fetch exploitdb
$ sqlite3 go-exploitdb.sqlite3
sqlite> select offensive_security_id, date from documents LIMIT 3;
offensive_security_id|date
1|2008-06-22 00:00:00+00:00
2|2008-06-22 00:00:00+00:00
3|2016-06-06 00:00:00+00:00
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

