### PR TITLE
feat(exploitdb): add the information of exploitdb-papers

### DIFF
--- a/commands/search.go
+++ b/commands/search.go
@@ -56,7 +56,7 @@ func searchExploit(cmd *cobra.Command, args []string) (err error) {
 	var results []*models.Exploit
 	switch searchType {
 	case "CVE":
-		if !cveIDRegexp.Match([]byte(param)) {
+		if !cveIDRegexp.MatchString(param) {
 			log15.Error("Specify the search type [CVE] parameters like `--param CVE-xxxx-xxxx`")
 			return errors.New("Invalid CVE Param")
 		}

--- a/commands/search.go
+++ b/commands/search.go
@@ -97,6 +97,10 @@ func searchExploit(cmd *cobra.Command, args []string) (err error) {
 				fmt.Println("\n  - Exploit Code or Proof of Concept:")
 				fmt.Printf("    %s\n", os.ShellCode.ShellCodeURL)
 			}
+			if os.Paper != nil {
+				fmt.Println("\n  - Paper:")
+				fmt.Printf("    %s\n", os.Paper.PaperURL)
+			}
 		}
 		fmt.Println("---------------------------------------")
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -74,6 +74,7 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.OffensiveSecurity{},
 		&models.Document{},
 		&models.ShellCode{},
+		&models.Paper{},
 		&models.GitHubRepository{},
 	).Error; err != nil {
 		return fmt.Errorf("Failed to migrate. err: %s", err)
@@ -84,6 +85,7 @@ func (r *RDBDriver) MigrateDB() error {
 	errs = errs.Add(r.conn.Model(&models.OffensiveSecurity{}).AddIndex("idx_offensive_security_exploit_unique_id", "exploit_unique_id").Error)
 	errs = errs.Add(r.conn.Model(&models.Document{}).AddIndex("idx_exploit_document_exploit_unique_id", "exploit_unique_id").Error)
 	errs = errs.Add(r.conn.Model(&models.ShellCode{}).AddIndex("idx_exploit_shell_code_exploit_unique_id", "exploit_unique_id").Error)
+	errs = errs.Add(r.conn.Model(&models.Paper{}).AddIndex("idx_exploit_paper_exploit_unique_id", "exploit_unique_id").Error)
 	errs = errs.Add(r.conn.Model(&models.GitHubRepository{}).AddIndex("idx_exploit_github_repository_exploit_unique_id", "exploit_unique_id").Error)
 
 	for _, e := range errs {
@@ -118,6 +120,7 @@ func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploits []*models.Exp
 		var errs gorm.Errors
 		errs = errs.Add(tx.Delete(models.Document{}).Error)
 		errs = errs.Add(tx.Delete(models.ShellCode{}).Error)
+		errs = errs.Add(tx.Delete(models.Paper{}).Error)
 		errs = errs.Add(tx.Delete(models.OffensiveSecurity{}).Error)
 		errs = errs.Add(tx.Delete(models.GitHubRepository{}).Error)
 		errs = errs.Add(tx.Delete(models.Exploit{}).Error)
@@ -154,7 +157,7 @@ func (r *RDBDriver) GetExploitByID(exploitUniqueID string) []*models.Exploit {
 		switch e.ExploitType {
 		case models.OffensiveSecurityType:
 			os := &models.OffensiveSecurity{}
-			errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
+			errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
 			e.OffensiveSecurity = os
 
 		case models.GitHubRepositoryType:
@@ -176,6 +179,7 @@ func (r *RDBDriver) GetExploitAll() []*models.Exploit {
 	es := []*models.Exploit{}
 	docs := []*models.Document{}
 	shells := []*models.ShellCode{}
+	papers := []*models.Paper{}
 	offensiveSecurities := []*models.OffensiveSecurity{}
 	var errs gorm.Errors
 
@@ -183,6 +187,7 @@ func (r *RDBDriver) GetExploitAll() []*models.Exploit {
 	errs = errs.Add(r.conn.Find(&offensiveSecurities).Error)
 	errs = errs.Add(r.conn.Find(&docs).Error)
 	errs = errs.Add(r.conn.Find(&shells).Error)
+	errs = errs.Add(r.conn.Find(&papers).Error)
 	if len(errs.GetErrors()) > 0 {
 		log15.Error("Failed to delete old records", "err", errs.Error())
 	}
@@ -197,6 +202,11 @@ func (r *RDBDriver) GetExploitAll() []*models.Exploit {
 			for _, s := range shells {
 				if o.ID == s.OffensiveSecurityID {
 					o.ShellCode = s
+				}
+			}
+			for _, p := range papers {
+				if o.ID == p.OffensiveSecurityID {
+					o.Paper = p
 				}
 			}
 			if e.ID == o.ExploitID {
@@ -225,7 +235,7 @@ func (r *RDBDriver) GetExploitByCveID(cveID string) []*models.Exploit {
 		switch e.ExploitType {
 		case models.OffensiveSecurityType:
 			os := &models.OffensiveSecurity{}
-			errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
+			errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
 			e.OffensiveSecurity = os
 
 		case models.GitHubRepositoryType:

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -183,12 +183,12 @@ func (r *RDBDriver) GetExploitByID(exploitUniqueID string) []*models.Exploit {
 		switch e.ExploitType {
 		case models.OffensiveSecurityType:
 			os := &models.OffensiveSecurity{}
-			errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
+			errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitID: e.ID}).First(&os).Error)
 			e.OffensiveSecurity = os
 
 		case models.GitHubRepositoryType:
 			gh := &models.GitHubRepository{}
-			errs = errs.Add(r.conn.Where(&models.GitHubRepository{ExploitUniqueID: e.ExploitUniqueID}).First(&gh).Error)
+			errs = errs.Add(r.conn.Where(&models.GitHubRepository{ExploitID: e.ID}).First(&gh).Error)
 			e.GitHubRepository = gh
 		}
 	}

--- a/fetcher/exploitdb.go
+++ b/fetcher/exploitdb.go
@@ -318,7 +318,7 @@ func FetchExploitPaperMap() (eidPaperMap map[string]*models.Paper, err error) {
 	}
 
 	for _, paper := range papers {
-		paper.PaperPath = "https://github.com/offensive-security/exploitdb-papers/blob/master/" + paper.PaperPath
+		paper.PaperURL = "https://github.com/offensive-security/exploitdb-papers/blob/master/" + paper.PaperURL
 		eidPaperMap[paper.ExploitUniqueID] = paper
 	}
 	return eidPaperMap, nil

--- a/fetcher/exploitdb.go
+++ b/fetcher/exploitdb.go
@@ -109,9 +109,10 @@ func FetchExploitDB(deep bool) (exploits []*models.Exploit, err error) {
 				URL:             "https://www.exploit-db.com/exploits/" + eid,
 				Description:     description,
 				OffensiveSecurity: &models.OffensiveSecurity{
-					Document:  exploitDocMap[eid],
-					ShellCode: exploitShellCodeMap[eid],
-					Paper:     exploitPaperMap[eid],
+					ExploitUniqueID: eid,
+					Document:        exploitDocMap[eid],
+					ShellCode:       exploitShellCodeMap[eid],
+					Paper:           exploitPaperMap[eid],
 				},
 			}
 			exploits = append(exploits, exploit)

--- a/fetcher/exploitdb.go
+++ b/fetcher/exploitdb.go
@@ -35,6 +35,11 @@ func FetchExploitDB(deep bool) (exploits []*models.Exploit, err error) {
 		return nil, err
 	}
 
+	var exploitPaperMap map[string]*models.Paper
+	if exploitPaperMap, err = FetchExploitPaperMap(); err != nil {
+		return nil, err
+	}
+
 	// distinct EID(nvd + github)
 	uniqEIDs := map[string]struct{}{}
 	for eid := range eidCvesMap {
@@ -46,12 +51,18 @@ func FetchExploitDB(deep bool) (exploits []*models.Exploit, err error) {
 	for eid := range exploitDocMap {
 		uniqEIDs[eid] = struct{}{}
 	}
+	for eid := range exploitPaperMap {
+		uniqEIDs[eid] = struct{}{}
+	}
 
 	for eid := range uniqEIDs {
 		cveIDs, ok := eidCvesMap[eid]
 		if ok {
 			for _, cveID := range cveIDs {
 				var description string
+				if e, ok := exploitPaperMap[eid]; ok {
+					description = e.Description
+				}
 				if e, ok := exploitShellCodeMap[eid]; ok {
 					description = e.Description
 				}
@@ -72,6 +83,7 @@ func FetchExploitDB(deep bool) (exploits []*models.Exploit, err error) {
 						ExploitUniqueID: eid,
 						Document:        exploitDocMap[eid],
 						ShellCode:       exploitShellCodeMap[eid],
+						Paper:           exploitPaperMap[eid],
 					},
 				}
 				exploits = append(exploits, exploit)
@@ -79,6 +91,9 @@ func FetchExploitDB(deep bool) (exploits []*models.Exploit, err error) {
 		} else {
 			// No CveID
 			var description string
+			if e, ok := exploitPaperMap[eid]; ok {
+				description = e.Description
+			}
 			if e, ok := exploitShellCodeMap[eid]; ok {
 				description = e.Description
 			}
@@ -96,6 +111,7 @@ func FetchExploitDB(deep bool) (exploits []*models.Exploit, err error) {
 				OffensiveSecurity: &models.OffensiveSecurity{
 					Document:  exploitDocMap[eid],
 					ShellCode: exploitShellCodeMap[eid],
+					Paper:     exploitPaperMap[eid],
 				},
 			}
 			exploits = append(exploits, exploit)
@@ -285,4 +301,25 @@ func FetchExploitDocumentMap() (eidDocMap map[string]*models.Document, err error
 		eidDocMap[doc.ExploitUniqueID] = doc
 	}
 	return eidDocMap, nil
+}
+
+// FetchExploitPaperMap :
+func FetchExploitPaperMap() (eidPaperMap map[string]*models.Paper, err error) {
+	eidPaperMap = map[string]*models.Paper{}
+	url := "https://raw.githubusercontent.com/offensive-security/exploitdb-papers/master/files_papers.csv"
+	log15.Info("Fetching", "URL", url)
+	cveCsv, err := util.FetchURL(url)
+	if err != nil {
+		return nil, err
+	}
+	papers := []*models.Paper{}
+	if err := gocsv.UnmarshalBytes(cveCsv, &papers); err != nil {
+		return nil, err
+	}
+
+	for _, paper := range papers {
+		paper.PaperPath = "https://github.com/offensive-security/exploitdb-papers/blob/master/" + paper.PaperPath
+		eidPaperMap[paper.ExploitUniqueID] = paper
+	}
+	return eidPaperMap, nil
 }

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -55,6 +55,7 @@ type OffensiveSecurity struct {
 // Document :
 // https://github.com/offensive-security/exploitdb/tree/master/exploits
 type Document struct {
+	// ID                  int64                 `json:"-"`
 	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:"-"`
 	ExploitUniqueID     string                `csv:"id" json:"-"`
 	DocumentURL         string                `csv:"file" json:"document_url"`
@@ -70,6 +71,7 @@ type Document struct {
 // ShellCode :
 // https://github.com/offensive-security/exploitdb/tree/master/shellcodes
 type ShellCode struct {
+	// ID                  int64                 `json:"-"`
 	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:"-"`
 	ExploitUniqueID     string                `csv:"id" json:"-"`
 	ShellCodeURL        string                `csv:"file" json:"shell_code_url"`
@@ -82,7 +84,7 @@ type ShellCode struct {
 // Paper :
 // https://github.com/offensive-security/exploitdb-papers/blob/master/files_papers.csv
 type Paper struct {
-	ID                  int64                 `json:"-"`
+	// ID                  int64                 `json:"-"`
 	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:"-"`
 	ExploitUniqueID     string                `csv:"id" json:"-"`
 	PaperURL            string                `csv:"file" json:"paper_path"`

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -84,7 +84,7 @@ type Paper struct {
 	ID                  int64                 `json:"-"`
 	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:"-"`
 	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
-	PaperPath           string                `csv:"file" json:"paper_path"`
+	PaperURL            string                `csv:"file" json:"paper_path"`
 	Description         string                `csv:"description" json:"description"`
 	Date                OffensiveSecurityTime `csv:"date" json:"date"`
 	Author              string                `csv:"author" json:"author"`

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -21,7 +21,7 @@ var (
 
 // Exploit :
 type Exploit struct {
-	ID                int64              `json:",omitempty"`
+	ID                int64              `json:"-"`
 	ExploitType       ExploitType        `json:"exploit_type"`
 	ExploitUniqueID   string             `json:"exploit_unique_id"`
 	URL               string             `json:"url"`
@@ -33,9 +33,9 @@ type Exploit struct {
 
 // GitHubRepository :
 type GitHubRepository struct {
-	ID              int64     `json:",omitempty"`
-	ExploitID       int64     `sql:"type:bigint REFERENCES exploits(id)" json:",omitempty"`
-	ExploitUniqueID string    `json:"exploit_unique_id"`
+	ID              int64     `json:"-"`
+	ExploitID       int64     `sql:"type:bigint REFERENCES exploits(id)" json:"-"`
+	ExploitUniqueID string    `json:"-"`
 	Star            int       `json:"star"`
 	Fork            int       `json:"fork"`
 	CreatedAt       time.Time `json:"created_at"`
@@ -44,9 +44,9 @@ type GitHubRepository struct {
 
 // OffensiveSecurity : https://www.exploit-db.com/
 type OffensiveSecurity struct {
-	ID              int64      `json:",omitempty"`
-	ExploitID       int64      `sql:"type:bigint REFERENCES exploits(id)" json:",omitempty"`
-	ExploitUniqueID string     `json:"exploit_unique_id"`
+	ID              int64      `json:"-"`
+	ExploitID       int64      `sql:"type:bigint REFERENCES exploits(id)" json:"-"`
+	ExploitUniqueID string     `json:"-"`
 	Document        *Document  `json:"document"`
 	ShellCode       *ShellCode `json:"shell_code"`
 	Paper           *Paper     `json:"paper"`
@@ -55,8 +55,8 @@ type OffensiveSecurity struct {
 // Document :
 // https://github.com/offensive-security/exploitdb/tree/master/exploits
 type Document struct {
-	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:",omitempty"`
-	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
+	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:"-"`
+	ExploitUniqueID     string                `csv:"id" json:"-"`
 	DocumentURL         string                `csv:"file" json:"document_url"`
 	Description         string                `csv:"description" json:"description"`
 	Date                OffensiveSecurityTime `csv:"date" json:"date"`
@@ -70,8 +70,8 @@ type Document struct {
 // ShellCode :
 // https://github.com/offensive-security/exploitdb/tree/master/shellcodes
 type ShellCode struct {
-	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:",omitempty"`
-	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
+	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:"-"`
+	ExploitUniqueID     string                `csv:"id" json:"-"`
 	ShellCodeURL        string                `csv:"file" json:"shell_code_url"`
 	Description         string                `csv:"description" json:"description"`
 	Date                OffensiveSecurityTime `csv:"date" json:"date"`
@@ -84,7 +84,7 @@ type ShellCode struct {
 type Paper struct {
 	ID                  int64                 `json:"-"`
 	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:"-"`
-	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
+	ExploitUniqueID     string                `csv:"id" json:"-"`
 	PaperURL            string                `csv:"file" json:"paper_path"`
 	Description         string                `csv:"description" json:"description"`
 	Date                OffensiveSecurityTime `csv:"date" json:"date"`

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -48,6 +48,7 @@ type OffensiveSecurity struct {
 	ExploitUniqueID string     `json:"exploit_unique_id"`
 	Document        *Document  `json:"document"`
 	ShellCode       *ShellCode `json:"shell_code"`
+	Paper           *Paper     `json:"paper"`
 }
 
 // Document :
@@ -75,6 +76,21 @@ type ShellCode struct {
 	Date                OffensiveSecurityTime `csv:"date" json:"date"`
 	Author              string                `csv:"author" json:"author"`
 	Platform            string                `csv:"platform" json:"platform"`
+}
+
+// Paper :
+// https://github.com/offensive-security/exploitdb-papers/blob/master/files_papers.csv
+type Paper struct {
+	ID                  int64                 `json:"-"`
+	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:"-"`
+	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
+	PaperPath           string                `csv:"file" json:"paper_path"`
+	Description         string                `csv:"description" json:"description"`
+	Date                OffensiveSecurityTime `csv:"date" json:"date"`
+	Author              string                `csv:"author" json:"author"`
+	Type                string                `csv:"type" json:"type"`
+	Platform            string                `csv:"platform" json:"platform"`
+	Language            string                `csv:"language" json:"language"`
 }
 
 // MitreXML :


### PR DESCRIPTION
# What did you implement:
The current `fetch exploitdb` inserts Exploits and Shellcodes information from [offensive-security/exploitdb](https://github.com/offensive-security/exploitdb).

In this PR, I would like to add information about [offensive-security/exploitdb-papers](https://github.com/offensive-security/exploitdb-papers) to `fetch exploitdb`. exploitdb-papers contains information about papers and so on.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
### Search by CVE-ID
```console
// PR
$ go-exploitdb search --type CVE --param CVE-2012-6613

Results: 
---------------------------------------

[*]CVE-ExploitID Reference:
  CVE: CVE-2012-6613
  Exploit Type: OffensiveSecurity
  Exploit Unique ID: 22930
  URL: https://www.exploit-db.com/exploits/22930
  Description: D-Link DSR-250N Persistent Root Access

[*]Exploit Detail Info: 
  [*]OffensiveSecurity: 
  - Paper:
    https://github.com/offensive-security/exploitdb-papers/blob/master/papers/english/22930-d-link-dsr-250n-persistent-root-access.txt
---------------------------------------

// upstream/master
$ go-exploitdb search --type CVE --param CVE-2012-6613

Results: 
---------------------------------------
No Record Found
```

### Search by ExploitUniqueID
```console
$ go-exploitdb search --type ID --param 30061

Results: 
---------------------------------------

[*]CVE-ExploitID Reference:
  CVE: CVE-2013-5946
  Exploit Type: OffensiveSecurity
  Exploit Unique ID: 30061
  URL: https://www.exploit-db.com/exploits/30061
  Description: Zine: D-Link DSR Router Series - Remote Command Execution

[*]Exploit Detail Info: 
  [*]OffensiveSecurity: 
  - Paper:
    https://github.com/offensive-security/exploitdb-papers/blob/master/papers/english/30061-zine-d-link-dsr-router-series---remote-command-execution.txt
---------------------------------------

[*]CVE-ExploitID Reference:
  CVE: CVE-2013-7004
  Exploit Type: OffensiveSecurity
  Exploit Unique ID: 30061
  URL: https://www.exploit-db.com/exploits/30061
  Description: Zine: D-Link DSR Router Series - Remote Command Execution

[*]Exploit Detail Info: 
  [*]OffensiveSecurity: 
  - Paper:
    https://github.com/offensive-security/exploitdb-papers/blob/master/papers/english/30061-zine-d-link-dsr-router-series---remote-command-execution.txt
---------------------------------------

[*]CVE-ExploitID Reference:
  CVE: CVE-2013-7005
  Exploit Type: OffensiveSecurity
  Exploit Unique ID: 30061
  URL: https://www.exploit-db.com/exploits/30061
  Description: Zine: D-Link DSR Router Series - Remote Command Execution

[*]Exploit Detail Info: 
  [*]OffensiveSecurity: 
  - Paper:
    https://github.com/offensive-security/exploitdb-papers/blob/master/papers/english/30061-zine-d-link-dsr-router-series---remote-command-execution.txt
---------------------------------------
```

### Query modification
The `offensive_security_id` used in WHERE when searching for `documents`, `shell_codes`, (`papers`) has been changed to use the correct one.
The upstream/master only uses offensive_securities.id:7449.  The query should use both 7449 and 7500. It has been fixed as such.

```console
sqlite> SELECT id FROM "exploits"  WHERE ("exploits"."exploit_unique_id" = '6560');
id
7449
7450
sqlite> SELECT * FROM "offensive_securities"  WHERE ("offensive_securities"."exploit_unique_id" = '6560');
id|exploit_id|exploit_unique_id
7449|7449|6560
7450|7450|6560

// PR
$ go-exploitdb search --type ID --param 6560 --debug-sql

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:53) 
[2021-06-28 12:38:47]  [0.05ms]  PRAGMA foreign_keys = ON  
[0 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:181) 
[2021-06-28 12:38:47]  [8.18ms]  SELECT * FROM "exploits"  WHERE ("exploits"."exploit_unique_id" = '6560')  
[2 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:186) 
[2021-06-28 12:38:47]  [0.70ms]  SELECT * FROM "offensive_securities"  WHERE ("offensive_securities"."exploit_id" = 7449) ORDER BY "offensive_securities"."id" ASC LIMIT 1  
[1 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:186) 
[2021-06-28 12:38:47]  [6.43ms]  SELECT * FROM "documents"  WHERE ("offensive_security_id" IN (7449)) ORDER BY "documents"."id" ASC  
[0 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:186) 
[2021-06-28 12:38:47]  [0.24ms]  SELECT * FROM "shell_codes"  WHERE ("offensive_security_id" IN (7449)) ORDER BY "shell_codes"."id" ASC  
[0 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:186) 
[2021-06-28 12:38:47]  [0.30ms]  SELECT * FROM "papers"  WHERE ("offensive_security_id" IN (7449)) ORDER BY "papers"."id" ASC  
[0 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:186) 
[2021-06-28 12:38:47]  [0.38ms]  SELECT * FROM "offensive_securities"  WHERE ("offensive_securities"."exploit_id" = 7450) ORDER BY "offensive_securities"."id" ASC LIMIT 1  
[1 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:186) 
[2021-06-28 12:38:47]  [9.16ms]  SELECT * FROM "documents"  WHERE ("offensive_security_id" IN (7450)) ORDER BY "documents"."id" ASC  
[1 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:186) 
[2021-06-28 12:38:47]  [0.36ms]  SELECT * FROM "shell_codes"  WHERE ("offensive_security_id" IN (7450)) ORDER BY "shell_codes"."id" ASC  
[0 rows affected or returned ] 

(/home/mainek00n/github/github.com/MaineK00n/go-exploitdb/db/rdb.go:186) 
[2021-06-28 12:38:47]  [0.44ms]  SELECT * FROM "papers"  WHERE ("offensive_security_id" IN (7450)) ORDER BY "papers"."id" ASC  
[0 rows affected or returned ]

// upstream/master
$ go-exploitdb search --type ID --param 6560 --debug-sql

(/home/mainek00n/go/src/github.com/mozqnet/go-exploitdb/db/rdb.go:54) 
[2021-06-28 12:37:43]  [0.06ms]  PRAGMA foreign_keys = ON  
[0 rows affected or returned ] 

(/home/mainek00n/go/src/github.com/mozqnet/go-exploitdb/db/rdb.go:152) 
[2021-06-28 12:37:43]  [8.77ms]  SELECT * FROM "exploits"  WHERE ("exploits"."exploit_unique_id" = '6560')  
[2 rows affected or returned ] 

(/home/mainek00n/go/src/github.com/mozqnet/go-exploitdb/db/rdb.go:157) 
[2021-06-28 12:37:43]  [0.19ms]  SELECT * FROM "offensive_securities"  WHERE ("offensive_securities"."exploit_unique_id" = '6560') ORDER BY "offensive_securities"."id" ASC LIMIT 1  
[1 rows affected or returned ] 

(/home/mainek00n/go/src/github.com/mozqnet/go-exploitdb/db/rdb.go:157) 
[2021-06-28 12:37:43]  [5.25ms]  SELECT * FROM "documents"  WHERE ("offensive_security_id" IN (7449))  
[0 rows affected or returned ] 

(/home/mainek00n/go/src/github.com/mozqnet/go-exploitdb/db/rdb.go:157) 
[2021-06-28 12:37:43]  [0.32ms]  SELECT * FROM "shell_codes"  WHERE ("offensive_security_id" IN (7449))  
[0 rows affected or returned ] 

(/home/mainek00n/go/src/github.com/mozqnet/go-exploitdb/db/rdb.go:157) 
[2021-06-28 12:37:43]  [0.15ms]  SELECT * FROM "offensive_securities"  WHERE ("offensive_securities"."exploit_unique_id" = '6560') ORDER BY "offensive_securities"."id" ASC LIMIT 1  
[1 rows affected or returned ] 

(/home/mainek00n/go/src/github.com/mozqnet/go-exploitdb/db/rdb.go:157) 
[2021-06-28 12:37:43]  [6.34ms]  SELECT * FROM "documents"  WHERE ("offensive_security_id" IN (7449))  
[0 rows affected or returned ] 

(/home/mainek00n/go/src/github.com/mozqnet/go-exploitdb/db/rdb.go:157) 
[2021-06-28 12:37:43]  [0.33ms]  SELECT * FROM "shell_codes"  WHERE ("offensive_security_id" IN (7449))  
[0 rows affected or returned ]
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference
- https://github.com/offensive-security/exploitdb-papers
