### PR TITLE
feat(rdb): add a note that deleting old records is time consuming

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -117,6 +117,7 @@ func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploitType models.Exp
 	}
 
 	if result.RowsAffected > 0 {
+		log15.Info(fmt.Sprintf("Deleting records that match exploit_type = %s from your DB. This will take some time.", exploitType))
 		for _, oldID := range oldIDs {
 			osIDs := []models.OffensiveSecurity{}
 			if err := tx.Table("offensive_securities").Select("id").Where("exploit_id = ?", oldID.ID).Find(&osIDs).Error; err != nil {


### PR DESCRIPTION
# What did you implement:
Deleting records matching the exploit_type to be fetched is time consuming. (GORMv2 will fix this. #47)
So just log it once and note it.

If you have no problem, it may be faster to delete the DB itself and then fetch it.

The progress bar is two-tiered, but don't worry about that, because GORMv2 finishes so quickly that there is no need to log it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```console
$ go-exploitdb fetch exploitdb
INFO[06-25|10:54:39] Fetching Offensive Security Exploit 
INFO[06-25|10:54:39] Fetching                                 URL=https://cve.mitre.org/data/downloads/allitems-cvrf.xml
INFO[06-25|10:55:21] Fetching                                 URL=https://raw.githubusercontent.com/offensive-security/exploitdb/master/files_shellcodes.csv
INFO[06-25|10:55:22] Fetching                                 URL=https://raw.githubusercontent.com/offensive-security/exploitdb/master/files_exploits.csv
INFO[06-25|10:55:22] Offensive Security Exploit               count=46825
INFO[06-25|10:55:22] Insert Exploit into go-exploitdb.        db=sqlite3
INFO[06-25|10:55:22] Inserting 46825 Exploits 
0 / 46825 [_________________________________________________________________________________] 0.00% ? p/s
INFO[06-25|10:55:22] Deleting records that match exploit_type = OffensiveSecurity from your DB. This will take some time. 
0 / 46825 [_________________________________________________________________________________] 0.00% ? p/s
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

