### PR TITLE
feat(redis): add expire option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ $ make install
 
 ### Usage: Fetch and Insert Exploit
 ```bash
-$ Fetch the data of exploit
+$ go-exploitdb fetch --help
+Fetch the data of exploit
 
 Usage:
   go-exploitdb fetch [command]
@@ -55,12 +56,13 @@ Available Commands:
   githubrepos Fetch the data of github repos
 
 Flags:
-  -h, --help   help for fetch
+      --expire uint   timeout to set for Redis keys
+  -h, --help          help for fetch
 
 Global Flags:
       --config string       config file (default is $HOME/.go-exploitdb.yaml)
       --dbpath string       /path/to/sqlite3 or SQL connection string
-      --dbtype string       Database type to store data in (sqlite3, mysql, postgres, or redis supported)
+      --dbtype string       Database type to store data in (sqlite3, mysql, postgres or redis supported)
       --debug               debug mode (default: false)
       --debug-sql           SQL debug mode
       --deep                deep mode extract cve-id from github sources

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Available Commands:
   githubrepos Fetch the data of github repos
 
 Flags:
-      --expire uint   timeout to set for Redis keys
+      --expire uint   timeout to set for Redis keys in seconds. If set to 0, the key is persistent.
   -h, --help          help for fetch
 
 Global Flags:

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -15,6 +15,6 @@ var fetchCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(fetchCmd)
 
-	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
 	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // fetchCmd represents the fetch command
@@ -13,4 +14,7 @@ var fetchCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(fetchCmd)
+
+	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -181,15 +181,16 @@ func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exp
 		}
 
 		if 0 < len(exploit.CveID) {
-			if result := pipe.HSet(ctx, cveIDPrefix+exploit.CveID, exploit.ExploitUniqueID, string(j)); result.Err() != nil {
+			key := cveIDPrefix + exploit.CveID
+			if result := pipe.HSet(ctx, key, exploit.ExploitUniqueID, string(j)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
 			if expire > 0 {
-				if err := pipe.Expire(ctx, cveIDPrefix+exploit.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 				}
 			} else {
-				if err := pipe.Persist(ctx, cveIDPrefix+exploit.CveID).Err(); err != nil {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
 					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
@@ -202,15 +203,17 @@ func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exp
 		if len(exploit.CveID) == 0 {
 			exploit.CveID = "NONE"
 		}
-		if result := pipe.HSet(ctx, exploitDBIDPrefix+exploit.ExploitUniqueID, exploit.CveID, string(j)); result.Err() != nil {
+
+		key := exploitDBIDPrefix + exploit.ExploitUniqueID
+		if result := pipe.HSet(ctx, key, exploit.CveID, string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet Exploit. err: %s", result.Err())
 		}
 		if expire > 0 {
-			if err := pipe.Expire(ctx, exploitDBIDPrefix+exploit.ExploitUniqueID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+			if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
 		} else {
-			if err := pipe.Persist(ctx, exploitDBIDPrefix+exploit.ExploitUniqueID).Err(); err != nil {
+			if err := pipe.Persist(ctx, key).Err(); err != nil {
 				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 			}
 		}

--- a/db/redis.go
+++ b/db/redis.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/go-redis/redis/v8"
 	"github.com/inconshreveable/log15"
+	"github.com/spf13/viper"
 	"github.com/vulsio/go-exploitdb/models"
 	"golang.org/x/xerrors"
 )
@@ -163,6 +165,8 @@ func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) (exploitsMap map[s
 
 //InsertExploit :
 func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exploit) (err error) {
+	expire := viper.GetUint("expire")
+
 	ctx := context.Background()
 	bar := pb.StartNew(len(exploits))
 
@@ -181,6 +185,11 @@ func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exp
 			if result := pipe.HSet(ctx, cveIDPrefix+exploit.CveID, exploit.ExploitUniqueID, string(j)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
+			if expire > 0 {
+				if err := pipe.Expire(ctx, cveIDPrefix+exploit.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			}
 			cveIDExploitCount++
 		} else {
 			noCveIDExploitCount++
@@ -192,6 +201,11 @@ func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exp
 		}
 		if result := pipe.HSet(ctx, exploitDBIDPrefix+exploit.ExploitUniqueID, exploit.CveID, string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet Exploit. err: %s", result.Err())
+		}
+		if expire > 0 {
+			if err := pipe.Expire(ctx, exploitDBIDPrefix+exploit.ExploitUniqueID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+			}
 		}
 
 		if _, err = pipe.Exec(ctx); err != nil {

--- a/db/redis.go
+++ b/db/redis.go
@@ -172,8 +172,7 @@ func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exp
 
 	var noCveIDExploitCount, cveIDExploitCount int
 	for _, exploit := range exploits {
-		var pipe redis.Pipeliner
-		pipe = r.conn.Pipeline()
+		pipe := r.conn.Pipeline()
 		bar.Increment()
 
 		j, err := json.Marshal(exploit)
@@ -188,6 +187,10 @@ func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exp
 			if expire > 0 {
 				if err := pipe.Expire(ctx, cveIDPrefix+exploit.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, cveIDPrefix+exploit.CveID).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 			cveIDExploitCount++
@@ -205,6 +208,10 @@ func (r *RedisDriver) InsertExploit(_ models.ExploitType, exploits []*models.Exp
 		if expire > 0 {
 			if err := pipe.Expire(ctx, exploitDBIDPrefix+exploit.ExploitUniqueID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+			}
+		} else {
+			if err := pipe.Persist(ctx, exploitDBIDPrefix+exploit.ExploitUniqueID).Err(); err != nil {
+				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 			}
 		}
 


### PR DESCRIPTION
# What did you implement:
Unlike RDBs, Redis does not lose old data. For users who do not want to be affected by old data remaining, it is possible to set a timeout deadline for keys using the Redis EXPIRE command.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```console
$ redis-cli -p 6379
127.0.0.1:6379> TTL "EXPLOIT#E#44513"
(integer) 70
127.0.0.1:6379> TTL "EXPLOIT#C#CVE-2006-5673"
(integer) 60
127.0.0.1:6379> keys EXPLOIT#*
(empty array)
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://redis.io/commands/expire