### PR TITLE
chore: change default threshold in fetch githubrepos

### DIFF
--- a/commands/fetch-githubrepos.go
+++ b/commands/fetch-githubrepos.go
@@ -19,10 +19,10 @@ var fetchGitHubReposCmd = &cobra.Command{
 func init() {
 	fetchCmd.AddCommand(fetchGitHubReposCmd)
 
-	fetchGitHubReposCmd.PersistentFlags().Int("threshold-stars", 5, "Threshold of Stars in PoC repository to be inserted into DB")
+	fetchGitHubReposCmd.PersistentFlags().Int("threshold-stars", 3, "Threshold of Stars in PoC repository to be inserted into DB")
 	_ = viper.BindPFlag("threshold-stars", fetchGitHubReposCmd.PersistentFlags().Lookup("threshold-stars"))
 
-	fetchGitHubReposCmd.PersistentFlags().Int("threshold-forks", 5, "Threshold of Forks in PoC repository to be inserted into DB")
+	fetchGitHubReposCmd.PersistentFlags().Int("threshold-forks", 0, "Threshold of Forks in PoC repository to be inserted into DB")
 	_ = viper.BindPFlag("threshold-forks", fetchGitHubReposCmd.PersistentFlags().Lookup("threshold-forks"))
 }
 


### PR DESCRIPTION
# What did you implement:
Change the (star, fork) threshold used in the `fetch githubrepos` command from (5, 5) to (3, 0).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```console
// upstream/master
$ go-exploitdb fetch githubrepos --threshold-stars 3 --threshold-forks 0
INFO[08-12|12:20:47] Fetching GitHub Repos Exploit 
INFO[08-12|12:20:50] GitHub Repos Exploit                     count=2127
INFO[08-12|12:20:50] Insert Exploit into go-exploitdb.        db=sqlite3
INFO[08-12|12:20:50] Inserting 2127 Exploits 
2127 / 2127 [-----------------------------------------------------------------------------] 100.00% ? p/s
INFO[08-12|12:20:50] No CveID Exploit Count                   count=0
INFO[08-12|12:20:50] CveID Exploit Count                      count=2127

// PR
$ go-exploitdb fetch githubrepos
INFO[08-12|12:21:22] Fetching GitHub Repos Exploit 
INFO[08-12|12:21:25] GitHub Repos Exploit                     count=2127
INFO[08-12|12:21:25] Insert Exploit into go-exploitdb.        db=sqlite3
INFO[08-12|12:21:25] Inserting 2127 Exploits 
2127 / 2127 [-----------------------------------------------------------------------------] 100.00% ? p/s
INFO[08-12|12:21:25] No CveID Exploit Count                   count=0
INFO[08-12|12:21:25] CveID Exploit Count                      count=2127
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

