### PR TITLE
chore(linter): change linter from golint to revive

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.32
+          version: v1.42
           args: --timeout=10m
           
           # Optional: working directory, useful for monorepos

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,44 @@
 name: golang-ci
 
 linters-settings:
-  errcheck:
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+  # errcheck:
     #exclude: /path/to/file.txt
 
 linters:
   disable-all: true
   enable:
     - goimports
-    - golint
+    - revive
     - govet
     - misspell
     - errcheck

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
   goarch:
   - amd64
   main: .
-  ldflags: -s -w -X main.version={{.Version}} -X main.revision={{.Commit}}
+  ldflags: -s -w -X github.com/vulsio/go-exploitdb/config.Version={{.Version}} -X github.com/vulsio/go-exploitdb/config.Revision={{.Commit}}
   binary: go-exploitdb
 archives:
 - name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,30 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,21 +22,25 @@
 	diff-server-rdb-redis
 
 SRCS = $(shell git ls-files '*.go')
-PKGS =  ./commands ./config ./db ./fetcher ./models ./util ./server
+PKGS = $(shell go list ./...)
 VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
 LDFLAGS := -X 'github.com/vulsio/go-exploitdb/config.Version=$(VERSION)' \
 	-X 'github.com/vulsio/go-exploitdb/config.Revision=$(REVISION)'
+GO := GO111MODULE=on go
+GO_OFF := GO111MODULE=off go
 
-all: build test
+all: build
 
-build: main.go
-	go build -ldflags "$(LDFLAGS)" -o go-exploitdb $<
+build: main.go pretest
+	$(GO) build -ldflags "$(LDFLAGS)" -o go-exploitdb $<
 
-install: main.go
-	go install -ldflags "$(LDFLAGS)"
+install: main.go pretest
+	$(GO) install -ldflags "$(LDFLAGS)"
 
-all: test
+lint:
+	$(GO_OFF) get -u github.com/mgechev/revive
+	revive -config ./.revive.toml -formatter plain $(PKGS)
 
 vet:
 	$(foreach pkg,$(PKGS),go vet $(pkg);)
@@ -47,7 +51,7 @@ fmt:
 fmtcheck:
 	$(foreach file,$(SRCS),gofmt -d $(file);)
 
-pretest: vet fmtcheck
+pretest: lint vet fmtcheck
 
 test: pretest
 	$(foreach pkg,$(PKGS),go test -v $(pkg) || exit;)
@@ -67,10 +71,10 @@ PWD := $(shell pwd)
 BRANCH := $(shell git symbolic-ref --short HEAD)
 build-integration:
 	@ git stash save
-	go build -ldflags "$(LDFLAGS)" -o integration/exploitdb.new
+	$(GO) build -ldflags "$(LDFLAGS)" -o integration/exploitdb.new
 	git checkout $(shell git describe --tags --abbrev=0)
 	@git reset --hard
-	go build -ldflags "$(LDFLAGS)" -o integration/exploitdb.old
+	$(GO) build -ldflags "$(LDFLAGS)" -o integration/exploitdb.old
 	git checkout $(BRANCH)
 	@ git stash apply stash@{0} && git stash drop stash@{0}
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,8 @@
 .PHONY: \
+	all \
 	build \
 	install \
-	all \
-	vendor \
+	lint \
 	vet \
 	fmt \
 	fmtcheck \
@@ -32,10 +32,10 @@ GO_OFF := GO111MODULE=off go
 
 all: build
 
-build: main.go pretest
+build: main.go
 	$(GO) build -ldflags "$(LDFLAGS)" -o go-exploitdb $<
 
-install: main.go pretest
+install: main.go
 	$(GO) install -ldflags "$(LDFLAGS)"
 
 lint:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,7 +30,7 @@ LDFLAGS := -X 'github.com/vulsio/go-exploitdb/config.Version=$(VERSION)' \
 GO := GO111MODULE=on go
 GO_OFF := GO111MODULE=off go
 
-all: build
+all: build pretest
 
 build: main.go
 	$(GO) build -ldflags "$(LDFLAGS)" -o go-exploitdb $<

--- a/commands/fetch-awesomepoc.go
+++ b/commands/fetch-awesomepoc.go
@@ -22,7 +22,7 @@ func init() {
 	fetchCmd.AddCommand(fetchAwesomePocCmd)
 }
 
-func fetchAwesomePoc(cmd *cobra.Command, args []string) (err error) {
+func fetchAwesomePoc(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetch-exploitdb.go
+++ b/commands/fetch-exploitdb.go
@@ -22,7 +22,7 @@ func init() {
 	fetchCmd.AddCommand(fetchExploitDBCmd)
 }
 
-func fetchExploitDB(cmd *cobra.Command, args []string) (err error) {
+func fetchExploitDB(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetch-githubrepos.go
+++ b/commands/fetch-githubrepos.go
@@ -28,7 +28,7 @@ func init() {
 	_ = viper.BindPFlag("threshold-forks", fetchGitHubReposCmd.PersistentFlags().Lookup("threshold-forks"))
 }
 
-func fetchGitHubRepos(cmd *cobra.Command, args []string) (err error) {
+func fetchGitHubRepos(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/search.go
+++ b/commands/search.go
@@ -37,7 +37,7 @@ func init() {
 	viper.SetDefault("param", "")
 }
 
-func searchExploit(cmd *cobra.Command, args []string) error {
+func searchExploit(_ *cobra.Command, _ []string) error {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -31,7 +31,7 @@ func init() {
 
 }
 
-func executeServer(cmd *cobra.Command, args []string) (err error) {
+func executeServer(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -42,7 +42,7 @@ func (r *RDBDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, _ Option) (locked bool, err error) {
 	gormConfig := gorm.Config{
 		DisableForeignKeyConstraintWhenMigrating: true,
 		Logger: logger.New(

--- a/db/redis.go
+++ b/db/redis.go
@@ -61,7 +61,7 @@ func (r *RedisDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RedisDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RedisDriver) OpenDB(dbType, dbPath string, _ bool, option Option) (locked bool, err error) {
 	if err = r.connectRedis(dbPath, option); err != nil {
 		err = xerrors.Errorf("Failed to open DB. dbtype: %s, dbpath: %s, err: %w", dbType, dbPath, err)
 	}

--- a/fetcher/awesomepoc.go
+++ b/fetcher/awesomepoc.go
@@ -31,7 +31,7 @@ type AwesomePocReader struct {
 }
 
 // RenderNode :
-func (r *AwesomePocReader) RenderNode(w io.Writer, node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+func (r *AwesomePocReader) RenderNode(_ io.Writer, node *blackfriday.Node, _ bool) blackfriday.WalkStatus {
 	// start extracting from the text "Resource"
 	if string(node.Literal) == "Resource" {
 		r.Start = true
@@ -72,11 +72,11 @@ func (r *AwesomePocReader) RenderNode(w io.Writer, node *blackfriday.Node, enter
 }
 
 // RenderHeader :
-func (r *AwesomePocReader) RenderHeader(w io.Writer, ast *blackfriday.Node) {
+func (r *AwesomePocReader) RenderHeader(_ io.Writer, _ *blackfriday.Node) {
 }
 
 // RenderFooter :
-func (r *AwesomePocReader) RenderFooter(w io.Writer, ast *blackfriday.Node) {
+func (r *AwesomePocReader) RenderFooter(_ io.Writer, _ *blackfriday.Node) {
 	emptyAwesomePoc := AwesomePoc{}
 	if r.FillingAwesomePoc != emptyAwesomePoc {
 		r.AwesomePoc[r.FillingAwesomePoc] = struct{}{}

--- a/integration/diff_server_mode.py
+++ b/integration/diff_server_mode.py
@@ -32,9 +32,9 @@ def diff_response(args: Tuple[str, list[str]]):
     path = ""
     if args[0] in ['cveid', 'uniqueid']:
         if args[0] == 'cveid':
-            path = f'cves/{args[1]}'
+            path = f'cves/{args[1][0]}'
         if args[0] == 'uniqueid':
-            path = f'id/{args[1]}'
+            path = f'id/{args[1][0]}'
 
         try:
             response_old = requests.get(

--- a/util/util.go
+++ b/util/util.go
@@ -66,7 +66,7 @@ func SetLogger(logToFile bool, logDir string, debug, logJSON bool) error {
 }
 
 // FetchURL returns HTTP response body
-func FetchURL(url string, apiKey ...string) ([]byte, error) {
+func FetchURL(url string) ([]byte, error) {
 	httpProxy := viper.GetString("http-proxy")
 
 	resp, body, errs := gorequest.New().Proxy(httpProxy).Get(url).Type("text").EndBytes()
@@ -158,10 +158,7 @@ func FileWalk(root string, targetFiles map[string]struct{}, walkFn func(r io.Rea
 		}
 		defer f.Close()
 
-		if err = walkFn(f, path); err != nil {
-			return err
-		}
-		return nil
+		return walkFn(f, path)
 	})
 	if err != nil {
 		return xerrors.Errorf("error in file walk: %w", err)


### PR DESCRIPTION
# What did you implement:
Change the linter to revive, since golint has been deprecated as follows.
> NOTE: Golint is deprecated and frozen. There's no drop-in replacement for it, but tools such as Staticcheck and go vet should be used instead.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ make lint
$ golangci-lint run -c .golangci.yml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

