### PR TITLE
fix(db): change fetchmeta insert order

### DIFF
--- a/commands/fetch-awesomepoc.go
+++ b/commands/fetch-awesomepoc.go
@@ -49,6 +49,11 @@ func fetchAwesomePoc(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
+		return err
+	}
+
 	log15.Info("Fetching Awesome Poc Exploit")
 	var exploits []models.Exploit
 	if exploits, err = fetcher.FetchAwesomePoc(); err != nil {
@@ -60,11 +65,6 @@ func fetchAwesomePoc(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
 	if err := driver.InsertExploit(models.AwesomePocType, exploits); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}
 

--- a/commands/fetch-exploitdb.go
+++ b/commands/fetch-exploitdb.go
@@ -49,6 +49,11 @@ func fetchExploitDB(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
+		return err
+	}
+
 	log15.Info("Fetching Offensive Security Exploit")
 	var exploits []models.Exploit
 	if exploits, err = fetcher.FetchExploitDB(); err != nil {
@@ -60,11 +65,6 @@ func fetchExploitDB(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
 	if err := driver.InsertExploit(models.OffensiveSecurityType, exploits); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}
 

--- a/commands/fetch-githubrepos.go
+++ b/commands/fetch-githubrepos.go
@@ -55,6 +55,11 @@ func fetchGitHubRepos(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
+		return err
+	}
+
 	log15.Info("Fetching GitHub Repos Exploit")
 	var exploits []models.Exploit
 	if exploits, err = fetcher.FetchGitHubRepos(viper.GetInt("threshold-stars"), viper.GetInt("threshold-forks")); err != nil {
@@ -66,11 +71,6 @@ func fetchGitHubRepos(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
 	if err := driver.InsertExploit(models.GitHubRepositoryType, exploits); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "dbpath", viper.GetString("dbpath"), "err", err)
 		return err
 	}
 


### PR DESCRIPTION
# What did you implement:
If an error occurs during the first fetch, it is required to clean the DB during the second Insert. 
The old data can be deleted when updating between the same schema versions.
To avoid this problem, insert FetchMeta first.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

