### PR TITLE
refactor(db): return error and use pipeline in Redis GetMulti

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -110,9 +110,11 @@ fetch-redis:
 
 diff-cveid:
 	@ python integration/diff_server_mode.py cveid --sample_rate 0.01
+	@ python integration/diff_server_mode.py cveids --sample_rate 0.01
 
 diff-uniqueid:
 	@ python integration/diff_server_mode.py uniqueid --sample_rate 0.01
+	@ python integration/diff_server_mode.py uniqueids --sample_rate 0.01
 
 diff-server-rdb:
 	integration/exploitdb.old server --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3 --port 1325 > /dev/null 2>&1 & 

--- a/commands/search.go
+++ b/commands/search.go
@@ -39,7 +39,7 @@ func init() {
 	viper.SetDefault("param", "")
 }
 
-func searchExploit(cmd *cobra.Command, args []string) (err error) {
+func searchExploit(cmd *cobra.Command, args []string) error {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}
@@ -66,13 +66,19 @@ func searchExploit(cmd *cobra.Command, args []string) (err error) {
 			log15.Error("Specify the search type [CVE] parameters like `--param CVE-xxxx-xxxx`")
 			return errors.New("Invalid CVE Param")
 		}
-		results = driver.GetExploitByCveID(param)
+		results, err = driver.GetExploitByCveID(param)
+		if err != nil {
+			return err
+		}
 	case "ID":
 		if !exploitDBIDRegexp.MatchString(param) {
 			log15.Error("Specify the search type [ID] parameters like `--param 10000`")
 			return errors.New("Invalid ID Param")
 		}
-		results = driver.GetExploitByID(param)
+		results, err = driver.GetExploitByID(param)
+		if err != nil {
+			return err
+		}
 	default:
 		log15.Error("Specify the search type [ CVE / ID].")
 		return errors.New("Invalid Type")

--- a/db/db.go
+++ b/db/db.go
@@ -14,11 +14,12 @@ type DB interface {
 	OpenDB(dbType, dbPath string, debugSQL bool) (bool, error)
 	CloseDB() error
 	MigrateDB() error
-	GetExploitByID(string) []models.Exploit
-	GetExploitByCveID(string) []models.Exploit
-	GetExploitMultiByCveID([]string) map[string][]models.Exploit
+	GetExploitByID(string) ([]models.Exploit, error)
+	GetExploitMultiByID([]string) (map[string][]models.Exploit, error)
+	GetExploitByCveID(string) ([]models.Exploit, error)
+	GetExploitMultiByCveID([]string) (map[string][]models.Exploit, error)
 	InsertExploit(models.ExploitType, []models.Exploit) error
-	GetExploitAll() []models.Exploit
+	GetExploitAll() ([]models.Exploit, error)
 
 	IsExploitModelV1() (bool, error)
 	GetFetchMeta() (*models.FetchMeta, error)

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -148,12 +148,11 @@ func (r *RDBDriver) deleteAndInsertExploit(exploitType models.ExploitType, explo
 	}
 
 	oldIDs := []int64{}
-	result := tx.Model(&models.Exploit{}).Select("id").Where("exploit_type = ?", exploitType).Find(&oldIDs)
-	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return xerrors.Errorf("Failed to select old defs: %w", result.Error)
+	if err := tx.Model(&models.Exploit{}).Select("id").Where("exploit_type = ?", exploitType).Find(&oldIDs).Error; err != nil {
+		return xerrors.Errorf("Failed to select old defs: %w", err)
 	}
 
-	if result.RowsAffected > 0 {
+	if len(oldIDs) > 0 {
 		log15.Info("Deleting old Exploits")
 		bar := pb.StartNew(len(oldIDs))
 		for idx := range chunkSlice(len(oldIDs), batchSize) {

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/vulsio/go-exploitdb/config"
 	"github.com/vulsio/go-exploitdb/models"
-	"github.com/vulsio/go-exploitdb/util"
 	"golang.org/x/xerrors"
 
 	"gorm.io/driver/mysql"
@@ -210,37 +209,40 @@ func (r *RDBDriver) deleteAndInsertExploit(exploitType models.ExploitType, explo
 }
 
 // GetExploitByID :
-func (r *RDBDriver) GetExploitByID(exploitUniqueID string) []models.Exploit {
+func (r *RDBDriver) GetExploitByID(exploitUniqueID string) ([]models.Exploit, error) {
 	es := []models.Exploit{}
-	var errs util.Errors
-	errs = errs.Add(r.conn.Where(&models.Exploit{ExploitUniqueID: exploitUniqueID}).Find(&es).Error)
+	if err := r.conn.Where(&models.Exploit{ExploitUniqueID: exploitUniqueID}).Find(&es).Error; err != nil {
+		log15.Error("Failed to get exploit by ExploitDB-ID", "err", err)
+		return nil, err
+	}
 	for i := range es {
 		switch es[i].ExploitType {
 		case models.OffensiveSecurityType:
-			errs = errs.Add(r.conn.
+			if err := r.conn.
 				Preload(clause.Associations).
 				Where(&models.OffensiveSecurity{ExploitID: es[i].ID}).
-				Take(&es[i].OffensiveSecurity).Error)
+				Take(&es[i].OffensiveSecurity).Error; err != nil {
+				log15.Error("Failed to get OffensiveSecurity", "err", err)
+				return nil, err
+			}
 		case models.GitHubRepositoryType:
-			errs = errs.Add(r.conn.Where(&models.GitHubRepository{ExploitID: es[i].ID}).Take(&es[i].GitHubRepository).Error)
+			if err := r.conn.Where(&models.GitHubRepository{ExploitID: es[i].ID}).Take(&es[i].GitHubRepository).Error; err != nil {
+				log15.Error("Failed to get GitHubRepository", "err", err)
+				return nil, err
+			}
 		}
 	}
-	for _, e := range errs.GetErrors() {
-		if !errors.Is(e, gorm.ErrRecordNotFound) {
-			log15.Error("Failed to get exploit by ExploitDB-ID", "err", e)
-		}
-	}
-	return es
+	return es, nil
 }
 
 // GetExploitAll :
-func (r *RDBDriver) GetExploitAll() []models.Exploit {
+func (r *RDBDriver) GetExploitAll() ([]models.Exploit, error) {
 	es := []models.Exploit{}
 
 	rows, err := r.conn.Model(&models.Exploit{}).Rows()
 	if err != nil {
 		log15.Error("Failed to Rows", "err", err)
-		return nil
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -248,7 +250,7 @@ func (r *RDBDriver) GetExploitAll() []models.Exploit {
 		exploit := models.Exploit{}
 		if err := r.conn.ScanRows(rows, &exploit); err != nil {
 			log15.Error("Failed to ScanRows", "err", err)
-			return nil
+			return nil, err
 		}
 		switch exploit.ExploitType {
 		case models.OffensiveSecurityType:
@@ -257,62 +259,71 @@ func (r *RDBDriver) GetExploitAll() []models.Exploit {
 				Where(&models.OffensiveSecurity{ExploitID: exploit.ID}).
 				Take(&exploit.OffensiveSecurity).Error; err != nil {
 				log15.Error("Failed to Get OffensiveSecurity", "err", err)
-				return nil
+				return nil, err
 			}
 		case models.GitHubRepositoryType:
 			if err := r.conn.Where(&models.GitHubRepository{ExploitID: exploit.ID}).Take(&exploit.GitHubRepository).Error; err != nil {
 				log15.Error("Failed to Get GitHubRepository", "err", err)
-				return nil
+				return nil, err
 			}
 		}
 		es = append(es, exploit)
 	}
 
-	return es
+	return es, nil
 }
 
 // GetExploitMultiByID :
-func (r *RDBDriver) GetExploitMultiByID(exploitUniqueIDs []string) map[string][]models.Exploit {
+func (r *RDBDriver) GetExploitMultiByID(exploitUniqueIDs []string) (map[string][]models.Exploit, error) {
 	exploits := map[string][]models.Exploit{}
 	for _, exploitUniqueID := range exploitUniqueIDs {
-		exploits[exploitUniqueID] = r.GetExploitByID(exploitUniqueID)
+		exploit, err := r.GetExploitByID(exploitUniqueID)
+		if err != nil {
+			return nil, err
+		}
+		exploits[exploitUniqueID] = exploit
 	}
-	return exploits
+	return exploits, nil
 }
 
 // GetExploitByCveID :
-func (r *RDBDriver) GetExploitByCveID(cveID string) []models.Exploit {
+func (r *RDBDriver) GetExploitByCveID(cveID string) ([]models.Exploit, error) {
 	es := []models.Exploit{}
-	var errs util.Errors
-
-	errs = errs.Add(r.conn.Where(&models.Exploit{CveID: cveID}).Find(&es).Error)
+	if err := r.conn.Where(&models.Exploit{CveID: cveID}).Find(&es).Error; err != nil {
+		log15.Error("Failed to get exploit by ExploitDB-ID", "err", err)
+		return nil, err
+	}
 	for i := range es {
 		switch es[i].ExploitType {
 		case models.OffensiveSecurityType:
-			errs = errs.Add(r.conn.
+			if err := r.conn.
 				Preload(clause.Associations).
 				Where(&models.OffensiveSecurity{ExploitID: es[i].ID}).
-				Take(&es[i].OffensiveSecurity).Error)
+				Take(&es[i].OffensiveSecurity).Error; err != nil {
+				log15.Error("Failed to get OffensiveSecurity", "err", err)
+				return nil, err
+			}
 		case models.GitHubRepositoryType:
-			errs = errs.Add(r.conn.Where(&models.GitHubRepository{ExploitID: es[i].ID}).Take(&es[i].GitHubRepository).Error)
+			if err := r.conn.Where(&models.GitHubRepository{ExploitID: es[i].ID}).Take(&es[i].GitHubRepository).Error; err != nil {
+				log15.Error("Failed to get GitHubRepository", "err", err)
+				return nil, err
+			}
 		}
 	}
-
-	for _, e := range errs.GetErrors() {
-		if !errors.Is(e, gorm.ErrRecordNotFound) {
-			log15.Error("Failed to get exploit by CveID", "err", e)
-		}
-	}
-	return es
+	return es, nil
 }
 
 // GetExploitMultiByCveID :
-func (r *RDBDriver) GetExploitMultiByCveID(cveIDs []string) (exploits map[string][]models.Exploit) {
-	exploits = map[string][]models.Exploit{}
+func (r *RDBDriver) GetExploitMultiByCveID(cveIDs []string) (map[string][]models.Exploit, error) {
+	exploits := map[string][]models.Exploit{}
 	for _, cveID := range cveIDs {
-		exploits[cveID] = r.GetExploitByCveID(cveID)
+		exploit, err := r.GetExploitByCveID(cveID)
+		if err != nil {
+			return nil, err
+		}
+		exploits[cveID] = exploit
 	}
-	return exploits
+	return exploits, nil
 }
 
 // IsExploitModelV1 determines if the DB was created at the time of go-exploitdb Model v1

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -221,11 +221,17 @@ func (r *RDBDriver) GetExploitByID(exploitUniqueID string) ([]models.Exploit, er
 				Preload(clause.Associations).
 				Where(&models.OffensiveSecurity{ExploitID: es[i].ID}).
 				Take(&es[i].OffensiveSecurity).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get OffensiveSecurity. DB relationship may be broken, use `$ go-exploitdb fetch exploitdb` to recreate DB. err: %w", err)
+				}
 				log15.Error("Failed to get OffensiveSecurity", "err", err)
 				return nil, err
 			}
 		case models.GitHubRepositoryType:
 			if err := r.conn.Where(&models.GitHubRepository{ExploitID: es[i].ID}).Take(&es[i].GitHubRepository).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get GitHubRepository. DB relationship may be broken, use `$ go-exploitdb fetch githubrepos` to recreate DB. err: %w", err)
+				}
 				log15.Error("Failed to get GitHubRepository", "err", err)
 				return nil, err
 			}
@@ -257,11 +263,17 @@ func (r *RDBDriver) GetExploitAll() ([]models.Exploit, error) {
 				Preload(clause.Associations).
 				Where(&models.OffensiveSecurity{ExploitID: exploit.ID}).
 				Take(&exploit.OffensiveSecurity).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get OffensiveSecurity. DB relationship may be broken, use `$ go-exploitdb fetch exploitdb` to recreate DB. err: %w", err)
+				}
 				log15.Error("Failed to Get OffensiveSecurity", "err", err)
 				return nil, err
 			}
 		case models.GitHubRepositoryType:
 			if err := r.conn.Where(&models.GitHubRepository{ExploitID: exploit.ID}).Take(&exploit.GitHubRepository).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get GitHubRepository. DB relationship may be broken, use `$ go-exploitdb fetch githubrepos` to recreate DB. err: %w", err)
+				}
 				log15.Error("Failed to Get GitHubRepository", "err", err)
 				return nil, err
 			}
@@ -299,11 +311,17 @@ func (r *RDBDriver) GetExploitByCveID(cveID string) ([]models.Exploit, error) {
 				Preload(clause.Associations).
 				Where(&models.OffensiveSecurity{ExploitID: es[i].ID}).
 				Take(&es[i].OffensiveSecurity).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get OffensiveSecurity. DB relationship may be broken, use `$ go-exploitdb fetch exploitdb` to recreate DB. err: %w", err)
+				}
 				log15.Error("Failed to get OffensiveSecurity", "err", err)
 				return nil, err
 			}
 		case models.GitHubRepositoryType:
 			if err := r.conn.Where(&models.GitHubRepository{ExploitID: es[i].ID}).Take(&es[i].GitHubRepository).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get GitHubRepository. DB relationship may be broken, use `$ go-exploitdb fetch githubrepos` to recreate DB. err: %w", err)
+				}
 				log15.Error("Failed to get GitHubRepository", "err", err)
 				return nil, err
 			}

--- a/db/redis.go
+++ b/db/redis.go
@@ -134,7 +134,6 @@ func (r *RedisDriver) GetExploitByCveID(cveID string) ([]models.Exploit, error) 
 			log15.Error("Failed to Unmarshal json.", "err", err)
 			return nil, err
 		}
-
 		exploits = append(exploits, exploit)
 	}
 	return exploits, nil
@@ -219,26 +218,96 @@ func (r *RedisDriver) GetExploitAll() ([]models.Exploit, error) {
 
 // GetExploitMultiByID :
 func (r *RedisDriver) GetExploitMultiByID(exploitUniqueIDs []string) (map[string][]models.Exploit, error) {
-	exploits := map[string][]models.Exploit{}
+	ctx := context.Background()
+
+	if len(exploitUniqueIDs) == 0 {
+		return map[string][]models.Exploit{}, nil
+	}
+
+	m := map[string]*redis.StringStringMapCmd{}
+	pipe := r.conn.Pipeline()
 	for _, exploitUniqueID := range exploitUniqueIDs {
-		exploit, err := r.GetExploitByID(exploitUniqueID)
+		m[exploitUniqueID] = pipe.HGetAll(ctx, fmt.Sprintf(exploitDBIDKeyFormat, exploitUniqueID))
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		log15.Error("Failed to exec pipeline", "err", err)
+		return nil, err
+	}
+
+	exploits := map[string][]models.Exploit{}
+	for exploitUniqueID, cmd := range m {
+		results, err := cmd.Result()
 		if err != nil {
+			log15.Error("Failed to get Exploit by ExploitUniqueID.", "err", err)
 			return nil, err
 		}
-		exploits[exploitUniqueID] = exploit
+
+		es := []models.Exploit{}
+		for _, result := range results {
+			var exploit models.Exploit
+			if err := json.Unmarshal([]byte(result), &exploit); err != nil {
+				log15.Error("Failed to Unmarshal json.", "err", err)
+				return nil, err
+			}
+			es = append(es, exploit)
+		}
+		exploits[exploitUniqueID] = es
 	}
 	return exploits, nil
 }
 
 // GetExploitMultiByCveID :
 func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) (map[string][]models.Exploit, error) {
-	exploits := map[string][]models.Exploit{}
+	ctx := context.Background()
+
+	if len(cveIDs) == 0 {
+		return map[string][]models.Exploit{}, nil
+	}
+
+	m := map[string]*redis.StringSliceCmd{}
+	pipe := r.conn.Pipeline()
 	for _, cveID := range cveIDs {
-		exploit, err := r.GetExploitByCveID(cveID)
+		m[cveID] = pipe.SMembers(ctx, fmt.Sprintf(cveIDKeyFormat, cveID))
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		log15.Error("Failed to exec pipeline", "err", err)
+		return nil, err
+	}
+
+	exploits := map[string][]models.Exploit{}
+	for cveID, cmd := range m {
+		exploitIDs, err := cmd.Result()
 		if err != nil {
+			log15.Error("Failed to get Exploit by CVEID.", "err", err)
 			return nil, err
 		}
-		exploits[cveID] = exploit
+
+		pipe := r.conn.Pipeline()
+		for _, exploitID := range exploitIDs {
+			_ = pipe.HGet(ctx, fmt.Sprintf(exploitDBIDKeyFormat, exploitID), cveID)
+		}
+		cmders, err := pipe.Exec(ctx)
+		if err != nil {
+			log15.Error("Failed to exec pipeline.", "err", err)
+			return nil, err
+		}
+
+		es := []models.Exploit{}
+		for _, cmder := range cmders {
+			str, err := cmder.(*redis.StringCmd).Result()
+			if err != nil {
+				log15.Error("Failed to HGet.", "err", err)
+				return nil, err
+			}
+
+			var exploit models.Exploit
+			if err := json.Unmarshal([]byte(str), &exploit); err != nil {
+				log15.Error("Failed to Unmarshal json.", "err", err)
+				return nil, err
+			}
+			es = append(es, exploit)
+		}
+		exploits[cveID] = es
 	}
 	return exploits, nil
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -99,16 +99,16 @@ func (r *RedisDriver) MigrateDB() error {
 }
 
 // GetExploitByCveID :
-func (r *RedisDriver) GetExploitByCveID(cveID string) []models.Exploit {
+func (r *RedisDriver) GetExploitByCveID(cveID string) ([]models.Exploit, error) {
 	ctx := context.Background()
 
 	exploitIDs, err := r.conn.SMembers(ctx, fmt.Sprintf(cveIDKeyFormat, cveID)).Result()
 	if err != nil {
 		log15.Error("Failed to SMembers.", "err", err)
-		return nil
+		return nil, err
 	}
 	if len(exploitIDs) == 0 {
-		return []models.Exploit{}
+		return []models.Exploit{}, nil
 	}
 
 	pipe := r.conn.Pipeline()
@@ -118,7 +118,7 @@ func (r *RedisDriver) GetExploitByCveID(cveID string) []models.Exploit {
 	cmders, err := pipe.Exec(ctx)
 	if err != nil {
 		log15.Error("Failed to exec pipeline.", "err", err)
-		return nil
+		return nil, err
 	}
 
 	exploits := []models.Exploit{}
@@ -126,28 +126,28 @@ func (r *RedisDriver) GetExploitByCveID(cveID string) []models.Exploit {
 		str, err := cmder.(*redis.StringCmd).Result()
 		if err != nil {
 			log15.Error("Failed to HGet.", "err", err)
-			return nil
+			return nil, err
 		}
 
 		var exploit models.Exploit
 		if err := json.Unmarshal([]byte(str), &exploit); err != nil {
 			log15.Error("Failed to Unmarshal json.", "err", err)
-			return nil
+			return nil, err
 		}
 
 		exploits = append(exploits, exploit)
 	}
-	return exploits
+	return exploits, nil
 }
 
 // GetExploitByID :
-func (r *RedisDriver) GetExploitByID(exploitDBID string) []models.Exploit {
+func (r *RedisDriver) GetExploitByID(exploitDBID string) ([]models.Exploit, error) {
 	ctx := context.Background()
 
 	result, err := r.conn.HGetAll(ctx, fmt.Sprintf(exploitDBIDKeyFormat, exploitDBID)).Result()
 	if err != nil {
 		log15.Error("Failed to HGetAll.", "err", err)
-		return nil
+		return nil, err
 	}
 
 	exploits := []models.Exploit{}
@@ -155,15 +155,15 @@ func (r *RedisDriver) GetExploitByID(exploitDBID string) []models.Exploit {
 		var exploit models.Exploit
 		if err := json.Unmarshal([]byte(str), &exploit); err != nil {
 			log15.Error("Failed to Unmarshal json.", "err", err)
-			return nil
+			return nil, err
 		}
 		exploits = append(exploits, exploit)
 	}
-	return exploits
+	return exploits, nil
 }
 
 // GetExploitAll :
-func (r *RedisDriver) GetExploitAll() []models.Exploit {
+func (r *RedisDriver) GetExploitAll() ([]models.Exploit, error) {
 	ctx := context.Background()
 
 	exploitDBIDkeys := []string{}
@@ -174,7 +174,7 @@ func (r *RedisDriver) GetExploitAll() []models.Exploit {
 		keys, cursor, err = r.conn.Scan(ctx, cursor, fmt.Sprintf(exploitDBIDKeyFormat, "*"), 10).Result()
 		if err != nil {
 			log15.Error("Failed to Scan.", "err", err)
-			return nil
+			return nil, err
 		}
 
 		exploitDBIDkeys = append(exploitDBIDkeys, keys...)
@@ -184,7 +184,7 @@ func (r *RedisDriver) GetExploitAll() []models.Exploit {
 		}
 	}
 	if len(exploitDBIDkeys) == 0 {
-		return []models.Exploit{}
+		return []models.Exploit{}, nil
 	}
 
 	pipe := r.conn.Pipeline()
@@ -194,7 +194,7 @@ func (r *RedisDriver) GetExploitAll() []models.Exploit {
 	cmders, err := pipe.Exec(ctx)
 	if err != nil {
 		log15.Error("Failed to exec pipeline.", "err", err)
-		return nil
+		return nil, err
 	}
 
 	exploits := []models.Exploit{}
@@ -202,37 +202,45 @@ func (r *RedisDriver) GetExploitAll() []models.Exploit {
 		result, err := cmder.(*redis.StringStringMapCmd).Result()
 		if err != nil {
 			log15.Error("Failed to HGetAll.", "err", err)
-			return nil
+			return nil, err
 		}
 		for _, str := range result {
 			var exploit models.Exploit
 			if err := json.Unmarshal([]byte(str), &exploit); err != nil {
 				log15.Error("Failed to Unmarshal json.", "err", err)
-				return nil
+				return nil, err
 			}
 
 			exploits = append(exploits, exploit)
 		}
 	}
-	return exploits
+	return exploits, nil
 }
 
 // GetExploitMultiByID :
-func (r *RedisDriver) GetExploitMultiByID(exploitUniqueIDs []string) map[string][]models.Exploit {
+func (r *RedisDriver) GetExploitMultiByID(exploitUniqueIDs []string) (map[string][]models.Exploit, error) {
 	exploits := map[string][]models.Exploit{}
 	for _, exploitUniqueID := range exploitUniqueIDs {
-		exploits[exploitUniqueID] = r.GetExploitByID(exploitUniqueID)
+		exploit, err := r.GetExploitByID(exploitUniqueID)
+		if err != nil {
+			return nil, err
+		}
+		exploits[exploitUniqueID] = exploit
 	}
-	return exploits
+	return exploits, nil
 }
 
 // GetExploitMultiByCveID :
-func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) map[string][]models.Exploit {
+func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) (map[string][]models.Exploit, error) {
 	exploits := map[string][]models.Exploit{}
 	for _, cveID := range cveIDs {
-		exploits[cveID] = r.GetExploitByCveID(cveID)
+		exploit, err := r.GetExploitByCveID(cveID)
+		if err != nil {
+			return nil, err
+		}
+		exploits[cveID] = exploit
 	}
-	return exploits
+	return exploits, nil
 }
 
 //InsertExploit :

--- a/fetcher/exploitdb.go
+++ b/fetcher/exploitdb.go
@@ -151,10 +151,6 @@ func reproOffensiveSecurityData(document models.Document, shellcode models.Shell
 		}
 	}
 
-	if os.Document == nil && os.ShellCode == nil && os.Paper == nil {
-		return nil
-	}
-
 	return &os
 }
 

--- a/fetcher/exploitdb_test.go
+++ b/fetcher/exploitdb_test.go
@@ -278,7 +278,7 @@ func Test_ReproOffnsiveSecurityDa(t *testing.T) {
 					Language:        "",
 				},
 			},
-			expected: nil,
+			expected: &models.OffensiveSecurity{},
 		},
 	}
 

--- a/integration/diff_server_mode.py
+++ b/integration/diff_server_mode.py
@@ -146,9 +146,9 @@ else:
 
 list_path = None
 if args.mode in ['cveid', 'cveids']:
-    list_path = f"integration/{args.mode}.txt"
+    list_path = f"integration/cveid.txt"
 if args.mode in ['uniqueid', 'uniqueids']:
-    list_path = f"integration/{args.mode}.txt"
+    list_path = f"integration/uniqueid.txt"
 if not os.path.isfile(list_path):
     logger.error(f'Failed to find list path..., list_path: {list_path}')
     exit(1)

--- a/integration/diff_server_mode.py
+++ b/integration/diff_server_mode.py
@@ -14,55 +14,98 @@ import math
 import json
 import shutil
 import time
+import uuid
 
 
-def diff_response(args: Tuple[str, str]):
-    # Endpoint
-    # /cves/:id
-    # /id/:uniqueid
-    path = ""
-    if args[0] == 'cveid':
-        path = f'cves/{args[1]}'
-    if args[0] == 'uniqueid':
-        path = f'id/{args[1]}'
-
+def diff_response(args: Tuple[str, list[str]]):
     session = requests.Session()
     retries = Retry(total=5,
                     backoff_factor=1,
                     status_forcelist=[503, 504])
     session.mount("http://", HTTPAdapter(max_retries=retries))
 
-    try:
-        response_old = requests.get(
-            f'http://127.0.0.1:1325/{path}', timeout=(10.0, 10.0)).json()
-        response_new = requests.get(
-            f'http://127.0.0.1:1326/{path}', timeout=(10.0, 10.0)).json()
-    except requests.ConnectionError as e:
-        logger.error(
-            f'Failed to Connection..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
-        exit(1)
-    except requests.ReadTimeout as e:
-        logger.warning(
-            f'Failed to ReadTimeout..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
-    except Exception as e:
-        logger.error(
-            f'Failed to GET request..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
-        exit(1)
+    # Endpoint
+    # GET /cves/:id
+    # GET /id/:uniqueid
+    # POST /multi-cves
+    # POST /multi-ids
+    path = ""
+    if args[0] in ['cveid', 'uniqueid']:
+        if args[0] == 'cveid':
+            path = f'cves/{args[1]}'
+        if args[0] == 'uniqueid':
+            path = f'id/{args[1]}'
 
-    diff = DeepDiff(response_old, response_new, ignore_order=True)
-    if diff != {}:
-        logger.warning(
-            f'There is a difference between old and new(or RDB and Redis):\n {pprint.pformat({"args": args, "path": path}, indent=2)}')
+        try:
+            response_old = requests.get(
+                f'http://127.0.0.1:1325/{path}', timeout=(3.0, 10.0)).json()
+            response_new = requests.get(
+                f'http://127.0.0.1:1326/{path}', timeout=(3.0, 10.0)).json()
+        except requests.ConnectionError as e:
+            logger.error(
+                f'Failed to Connection..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+            exit(1)
+        except requests.ReadTimeout as e:
+            logger.warning(
+                f'Failed to ReadTimeout..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+        except Exception as e:
+            logger.error(
+                f'Failed to GET request..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+            exit(1)
 
-        diff_path = f'integration/diff/{args[0]}/{args[1]}'
-        with open(f'{diff_path}.old', 'w') as w:
-            w.write(json.dumps(response_old, indent=4))
-        with open(f'{diff_path}.new', 'w') as w:
-            w.write(json.dumps(response_new, indent=4))
+        diff = DeepDiff(response_old, response_new, ignore_order=True)
+        if diff != {}:
+            logger.warning(
+                f'There is a difference between old and new(or RDB and Redis):\n {pprint.pformat({"args": args, "path": path}, indent=2)}')
+
+            diff_path = f'integration/diff/{args[0]}/{args[1]}'
+            with open(f'{diff_path}.old', 'w') as w:
+                w.write(json.dumps(response_old, indent=4))
+            with open(f'{diff_path}.new', 'w') as w:
+                w.write(json.dumps(response_new, indent=4))
+    else:
+        if args[0] == 'cveids':
+            path = 'multi-cves'
+        if args[0] == 'uniqueids':
+            path = 'multi-ids'
+
+        k = math.ceil(len(args[1])/5)
+        for _ in range(5):
+            payload = {"args": random.sample(args[1], k)}
+            try:
+                response_old = session.post(
+                    f'http://127.0.0.1:1325/{path}', data=json.dumps(payload), headers={'content-type': 'application/json'}, timeout=(3.0, 10.0)).json()
+                response_new = session.post(
+                    f'http://127.0.0.1:1326/{path}', data=json.dumps(payload), headers={'content-type': 'application/json'}, timeout=(3.0, 10.0)).json()
+            except requests.ConnectionError as e:
+                logger.error(
+                    f'Failed to Connection..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+                exit(1)
+            except requests.ReadTimeout as e:
+                logger.warning(
+                    f'Failed to ReadTimeout..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+            except Exception as e:
+                logger.error(
+                    f'Failed to GET request..., err: {e}, {pprint.pformat({"args": args, "path": path}, indent=2)}')
+                exit(1)
+
+            diff = DeepDiff(response_old, response_new, ignore_order=True)
+            if diff != {}:
+                logger.warning(
+                    f'There is a difference between old and new(or RDB and Redis):\n {pprint.pformat({"args": args, "path": path}, indent=2)}')
+
+                title = uuid.uuid4()
+                diff_path = f'integration/diff/{args[0]}/{title}'
+                with open(f'{diff_path}.old', 'w') as w:
+                    w.write(json.dumps(
+                        {'args': args, 'response': response_old}, indent=4))
+                with open(f'{diff_path}.new', 'w') as w:
+                    w.write(json.dumps(
+                        {'args': args, 'response': response_new}, indent=4))
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('mode', choices=['cveid', 'uniqueid'],
+parser.add_argument('mode', choices=['cveid', 'cveids', 'uniqueid', 'uniqueids'],
                     help='Specify the mode to test.')
 parser.add_argument("--sample_rate", type=float, default=0.01,
                     help="Adjust the rate of data used for testing (len(test_data) * sample_rate)")
@@ -102,9 +145,9 @@ else:
     exit(1)
 
 list_path = None
-if args.mode == 'cveid':
+if args.mode in ['cveid', 'cveids']:
     list_path = f"integration/{args.mode}.txt"
-if args.mode == 'uniqueid':
+if args.mode in ['uniqueid', 'uniqueids']:
     list_path = f"integration/{args.mode}.txt"
 if not os.path.isfile(list_path):
     logger.error(f'Failed to find list path..., list_path: {list_path}')
@@ -118,6 +161,9 @@ os.makedirs(diff_path, exist_ok=True)
 with open(list_path) as f:
     list = [s.strip() for s in f.readlines()]
     list = random.sample(list, math.ceil(len(list) * args.sample_rate))
-    with ThreadPoolExecutor() as executor:
-        ins = ((args.mode, e) for e in list)
-        executor.map(diff_response, ins)
+    if args.mode in ['cveids', 'uniqueids']:
+        diff_response((args.mode, list))
+    else:
+        with ThreadPoolExecutor() as executor:
+            ins = ((args.mode, [e]) for e in list)
+            executor.map(diff_response, ins)

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,9 @@ func Start(logToFile bool, logDir string, driver db.DB) error {
 	// Routes
 	e.GET("/health", health())
 	e.GET("/cves/:cve", getExploitByCveID(driver))
+	e.POST("/multi-cves", getExploitMultiByCveID(driver))
 	e.GET("/id/:id", getExploitByID(driver))
+	e.POST("/multi-ids", getExploitMultiByID(driver))
 	e.GET("/all", getExploitAll(driver))
 
 	bindURL := fmt.Sprintf("%s:%s", viper.GetString("bind"), viper.GetString("port"))
@@ -57,9 +59,31 @@ func getExploitByCveID(driver db.DB) echo.HandlerFunc {
 		cve := context.Param("cve")
 		log15.Debug("Params", "CVE", cve)
 
-		exploits := driver.GetExploitByCveID(cve)
+		exploits, err := driver.GetExploitByCveID(cve)
 		if err != nil {
 			log15.Error("Failed to get Exploit Info by CVE.", "err", err)
+			return err
+		}
+		return context.JSON(http.StatusOK, exploits)
+	}
+}
+
+type param struct {
+	Args []string `json:"args"`
+}
+
+func getExploitMultiByCveID(driver db.DB) echo.HandlerFunc {
+	return func(context echo.Context) (err error) {
+		cveIDs := param{}
+		if err := context.Bind(&cveIDs); err != nil {
+			return err
+		}
+		log15.Debug("Params", "CVEIDs", cveIDs.Args)
+
+		exploits, err := driver.GetExploitMultiByCveID(cveIDs.Args)
+		if err != nil {
+			log15.Error("Failed to get Exploit Info by CVE.", "err", err)
+			return err
 		}
 		return context.JSON(http.StatusOK, exploits)
 	}
@@ -70,9 +94,27 @@ func getExploitByID(driver db.DB) echo.HandlerFunc {
 		exploitDBID := context.Param("id")
 		log15.Debug("Params", "ExploitDBID", exploitDBID)
 
-		exploit := driver.GetExploitByID(exploitDBID)
+		exploit, err := driver.GetExploitByID(exploitDBID)
 		if err != nil {
 			log15.Error("Failed to get Exploit Info by EDB-ID.", "err", err)
+			return err
+		}
+		return context.JSON(http.StatusOK, exploit)
+	}
+}
+
+func getExploitMultiByID(driver db.DB) echo.HandlerFunc {
+	return func(context echo.Context) (err error) {
+		edbIDs := param{}
+		if err := context.Bind(&edbIDs); err != nil {
+			return err
+		}
+		log15.Debug("Params", "ExploitDBIDs", edbIDs.Args)
+
+		exploit, err := driver.GetExploitMultiByID(edbIDs.Args)
+		if err != nil {
+			log15.Error("Failed to get Exploit Info by EDB-ID.", "err", err)
+			return err
 		}
 		return context.JSON(http.StatusOK, exploit)
 	}
@@ -80,9 +122,10 @@ func getExploitByID(driver db.DB) echo.HandlerFunc {
 
 func getExploitAll(driver db.DB) echo.HandlerFunc {
 	return func(context echo.Context) (err error) {
-		exploits := driver.GetExploitAll()
+		exploits, err := driver.GetExploitAll()
 		if err != nil {
 			log15.Error("Failed to get All Exploit.", "err", err)
+			return err
 		}
 		return context.JSON(http.StatusOK, exploits)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -82,47 +82,6 @@ func FetchURL(url string, apiKey ...string) ([]byte, error) {
 	return body, nil
 }
 
-// Errors has a set of errors that occurred in GORM
-type Errors []error
-
-// Add adds an error to a given slice of errors
-func (errs Errors) Add(newErrors ...error) Errors {
-	for _, err := range newErrors {
-		if err == nil {
-			continue
-		}
-
-		if errors, ok := err.(Errors); ok {
-			errs = errs.Add(errors...)
-		} else {
-			ok = true
-			for _, e := range errs {
-				if err == e {
-					ok = false
-				}
-			}
-			if ok {
-				errs = append(errs, err)
-			}
-		}
-	}
-	return errs
-}
-
-// Error takes a slice of all errors that have occurred and returns it as a formatted string
-func (errs Errors) Error() string {
-	var errors = []string{}
-	for _, e := range errs {
-		errors = append(errors, e.Error())
-	}
-	return strings.Join(errors, "; ")
-}
-
-// GetErrors gets all errors that have occurred and returns a slice of errors (Error type)
-func (errs Errors) GetErrors() []error {
-	return errs
-}
-
 // CacheDir return cache dir path string
 func CacheDir() string {
 	tmpDir, err := os.UserCacheDir()


### PR DESCRIPTION
# What did you implement:
Changed to return error for functions related to Get. 
Also, GetMulti in Redis uses a pipeline to search efficiently.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ patch -p1 < test.patch
$ make clean-integration && make build-integration
$ make fetch-rdb && make fetch-redis
$ make diff-server-rdb && make diff-server-redis && maek diff-server-rdb-redis
```

- test.patch
```diff
diff --git a/GNUmakefile b/GNUmakefile
index 8d5003e..a59b406 100644
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -73,7 +73,7 @@ BRANCH := $(shell git symbolic-ref --short HEAD)
 build-integration:
 	@ git stash save
 	go build -ldflags "$(LDFLAGS)" -o integration/exploitdb.new
-	git checkout $(shell git describe --tags --abbrev=0)
+	git checkout upstream/master
 	@git reset --hard
 	go build -ldflags "$(LDFLAGS)" -o integration/exploitdb.old
 	git checkout $(BRANCH)
@@ -109,26 +109,26 @@ fetch-redis:
 	integration/exploitdb.new fetch githubrepos --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
 
 diff-cveid:
-	@ python integration/diff_server_mode.py cveid --sample_rate 0.01
-	@ python integration/diff_server_mode.py cveids --sample_rate 0.01
+	@ python integration/diff_server_mode.py cveid --sample_rate 1.00
+	@ python integration/diff_server_mode.py cveids --sample_rate 1.00
 
 diff-uniqueid:
-	@ python integration/diff_server_mode.py uniqueid --sample_rate 0.01
-	@ python integration/diff_server_mode.py uniqueids --sample_rate 0.01
+	@ python integration/diff_server_mode.py uniqueid --sample_rate 1.00
+	@ python integration/diff_server_mode.py uniqueids --sample_rate 1.00
 
 diff-server-rdb:
 	integration/exploitdb.old server --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3 --port 1325 > /dev/null 2>&1 & 
 	integration/exploitdb.new server --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3 --port 1326 > /dev/null 2>&1 &
-	make diff-cveid
-	make diff-uniqueid
+	@ python integration/diff_server_mode.py cveid --sample_rate 1.00
+	@ python integration/diff_server_mode.py uniqueid --sample_rate 1.00
 	pkill exploitdb.old
 	pkill exploitdb.new
 
 diff-server-redis:
 	integration/exploitdb.old server --dbtype redis --dbpath "redis://127.0.0.1:6379/0" --port 1325 > /dev/null 2>&1 & 
 	integration/exploitdb.new server --dbtype redis --dbpath "redis://127.0.0.1:6380/0" --port 1326 > /dev/null 2>&1 &
-	make diff-cveid
-	make diff-uniqueid
+	@ python integration/diff_server_mode.py cveid --sample_rate 1.00
+	@ python integration/diff_server_mode.py uniqueid --sample_rate 1.00
 	pkill exploitdb.old
 	pkill exploitdb.new
 

```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

