### PR TITLE
refactor(redis): use pipeline effectively in GetExploitMultiByCveID

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -292,7 +292,9 @@ func (r *RDBDriver) GetExploitMultiByID(exploitUniqueIDs []string) (map[string][
 		if err != nil {
 			return nil, err
 		}
-		exploits[exploitUniqueID] = exploit
+		if len(exploit) > 0 {
+			exploits[exploitUniqueID] = exploit
+		}
 	}
 	return exploits, nil
 }
@@ -338,7 +340,9 @@ func (r *RDBDriver) GetExploitMultiByCveID(cveIDs []string) (map[string][]models
 		if err != nil {
 			return nil, err
 		}
-		exploits[cveID] = exploit
+		if len(exploit) > 0 {
+			exploits[cveID] = exploit
+		}
 	}
 	return exploits, nil
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -251,7 +251,9 @@ func (r *RedisDriver) GetExploitMultiByID(exploitUniqueIDs []string) (map[string
 			}
 			es = append(es, exploit)
 		}
-		exploits[exploitUniqueID] = es
+		if len(es) > 0 {
+			exploits[exploitUniqueID] = es
+		}
 	}
 	return exploits, nil
 }
@@ -309,7 +311,9 @@ func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) (map[string][]mode
 			}
 			es = append(es, exploit)
 		}
-		exploits[cveID] = es
+		if len(es) > 0 {
+			exploits[cveID] = es
+		}
 	}
 	return exploits, nil
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -274,7 +274,8 @@ func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) (map[string][]mode
 		return nil, err
 	}
 
-	exploits := map[string][]models.Exploit{}
+	mm := map[string][]*redis.StringCmd{}
+	pipe = r.conn.Pipeline()
 	for cveID, cmd := range m {
 		exploitIDs, err := cmd.Result()
 		if err != nil {
@@ -282,19 +283,20 @@ func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) (map[string][]mode
 			return nil, err
 		}
 
-		pipe := r.conn.Pipeline()
 		for _, exploitID := range exploitIDs {
-			_ = pipe.HGet(ctx, fmt.Sprintf(exploitDBIDKeyFormat, exploitID), cveID)
+			mm[cveID] = append(mm[cveID], pipe.HGet(ctx, fmt.Sprintf(exploitDBIDKeyFormat, exploitID), cveID))
 		}
-		cmders, err := pipe.Exec(ctx)
-		if err != nil {
-			log15.Error("Failed to exec pipeline.", "err", err)
-			return nil, err
-		}
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		log15.Error("Failed to exec pipeline.", "err", err)
+		return nil, err
+	}
 
+	exploits := map[string][]models.Exploit{}
+	for cveID, cmds := range mm {
 		es := []models.Exploit{}
-		for _, cmder := range cmders {
-			str, err := cmder.(*redis.StringCmd).Result()
+		for _, cmd := range cmds {
+			str, err := cmd.Result()
 			if err != nil {
 				log15.Error("Failed to HGet.", "err", err)
 				return nil, err


### PR DESCRIPTION
# What did you implement:
Use pipeline as much as possible in GetExploitMultiByCveID to speed up the process.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## Testing by maximum number of CVEIDs
```console
$ sqlite3 go-exploitdb.sqlite3
sqlite> SELECT COUNT(DISTINCT cve_id) FROM exploits;
13312 // CVEID: "" is included, so the actual number is 13311.

$ go-exploitdb fetch exploitdb --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ go-exploitdb server --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ curl -d @cveids.txt -H "Content-Type: application/json" 127.0.0.1:1326/multi-cves| jq . | grep  -E "CVE-.+: \[" | wc -l
13311
```
[cveids.txt](https://github.com/vulsio/go-exploitdb/files/7262787/cveids.txt)

## Performance verification with upstream/master
```console
// upstream/master
$ ntimes 30 -- curl -d @cveids.txt -H "Content-Type: application/json" 127.0.0.1:1326/multi-cves -s -o /dev/null -w "%{time_total}\n" | percentile
50%:	1.365865
66%:	1.383664
75%:	1.39458
80%:	1.41191
90%:	1.478591
95%:	1.509597
98%:	1.514997
99%:	1.514997
100%:	1.522855

// PR
$ ntimes 30 -- curl -d @cveids.txt -H "Content-Type: application/json" 127.0.0.1:1326/multi-cves -s -o /dev/null -w "%{time_total}\n" | percentile
50%:	0.323914
66%:	0.327229
75%:	0.3288
80%:	0.33136
90%:	0.332741
95%:	0.332904
98%:	0.339403
99%:	0.339403
100%:	0.402423
```

## diff test
```console
$ make clean-integration

$ git checkout upstream/master
$ git cherry-pick 8da7a0dd
$ make build && mv go-exploitdb integration/exploitdb.old

$ git checkout MaineK00n/refactor-redis-GetExploitMultiByCveID
$ make build && mv go-exploitdb integration/exploitdb.new

$ patch -p1 < test.patch
$ make fetch-rdb && make fetch-redis
$ make diff-server-rdb && make diff-server-redis && make diff-server-rdb-redis
```
- test.patch
```diff
diff --git a/GNUmakefile b/GNUmakefile
index 8d5003e..c8d8431 100644
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -109,12 +109,12 @@ fetch-redis:
 	integration/exploitdb.new fetch githubrepos --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
 
 diff-cveid:
-	@ python integration/diff_server_mode.py cveid --sample_rate 0.01
-	@ python integration/diff_server_mode.py cveids --sample_rate 0.01
+	@ python integration/diff_server_mode.py cveid --sample_rate 1.00
+	@ python integration/diff_server_mode.py cveids --sample_rate 1.00
 
 diff-uniqueid:
-	@ python integration/diff_server_mode.py uniqueid --sample_rate 0.01
-	@ python integration/diff_server_mode.py uniqueids --sample_rate 0.01
+	@ python integration/diff_server_mode.py uniqueid --sample_rate 1.00
+	@ python integration/diff_server_mode.py uniqueids --sample_rate 1.00
 
 diff-server-rdb:
 	integration/exploitdb.old server --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3 --port 1325 > /dev/null 2>&1 & 

```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

