### PR TITLE
breaking-change(redis): deprecated expire option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Available Commands:
   githubrepos Fetch the data of github repos
 
 Flags:
-      --batch-size int   The number of batch size to insert. NOTE: This Option does not work for dbtype: redis. (default 500)
-      --expire uint      timeout to set for Redis keys in seconds. If set to 0, the key is persistent.
+      --batch-size int   The number of batch size to insert. (default 500)
   -h, --help             help for fetch
 
 Global Flags:

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -15,9 +15,6 @@ var fetchCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(fetchCmd)
 
-	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
-	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
-
 	fetchCmd.PersistentFlags().Int("batch-size", 500, "The number of batch size to insert.")
 	_ = viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/go-redis/redis/v8"
@@ -299,7 +298,6 @@ func (r *RedisDriver) GetExploitMultiByCveID(cveIDs []string) (map[string][]mode
 //InsertExploit :
 func (r *RedisDriver) InsertExploit(exploitType models.ExploitType, exploits []models.Exploit) (err error) {
 	ctx := context.Background()
-	expire := viper.GetUint("expire")
 	batchSize := viper.GetInt("batch-size")
 	if batchSize < 1 {
 		return xerrors.Errorf("Failed to set batch-size. err: batch-size option is not set properly")
@@ -329,37 +327,16 @@ func (r *RedisDriver) InsertExploit(exploitType models.ExploitType, exploits []m
 				return xerrors.Errorf("Failed to marshal json. err: %w", err)
 			}
 
-			exploitDBIDKey := fmt.Sprintf(exploitDBIDKeyFormat, exploit.ExploitUniqueID)
-			if err := pipe.HSet(ctx, exploitDBIDKey, exploit.CveID, string(j)).Err(); err != nil {
+			if err := pipe.HSet(ctx, fmt.Sprintf(exploitDBIDKeyFormat, exploit.ExploitUniqueID), exploit.CveID, string(j)).Err(); err != nil {
 				return xerrors.Errorf("Failed to HSet Exploit. err: %w", err)
 			}
-			if expire > 0 {
-				if err := pipe.Expire(ctx, exploitDBIDKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-					return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-				}
-			} else {
-				if err := pipe.Persist(ctx, exploitDBIDKey).Err(); err != nil {
-					return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-				}
-			}
-
 			if _, ok := newDeps[exploit.ExploitUniqueID]; !ok {
 				newDeps[exploit.ExploitUniqueID] = map[string]struct{}{}
 			}
 
 			if exploit.CveID != "" {
-				cveKey := fmt.Sprintf(cveIDKeyFormat, exploit.CveID)
-				if err := pipe.SAdd(ctx, cveKey, exploit.ExploitUniqueID).Err(); err != nil {
+				if err := pipe.SAdd(ctx, fmt.Sprintf(cveIDKeyFormat, exploit.CveID), exploit.ExploitUniqueID).Err(); err != nil {
 					return xerrors.Errorf("Failed to SAdd CVE. err: %w", err)
-				}
-				if expire > 0 {
-					if err := pipe.Expire(ctx, cveKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-						return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-					}
-				} else {
-					if err := pipe.Persist(ctx, cveKey).Err(); err != nil {
-						return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-					}
 				}
 				cveIDExploitCount++
 			} else {
@@ -400,15 +377,6 @@ func (r *RedisDriver) InsertExploit(exploitType models.ExploitType, exploits []m
 	}
 	if err := pipe.HSet(ctx, depKey, string(exploitType), string(newDepsJSON)).Err(); err != nil {
 		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
-	}
-	if expire > 0 {
-		if err := pipe.Expire(ctx, depKey, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-			return xerrors.Errorf("Failed to set Expire to Key. err: %w", err)
-		}
-	} else {
-		if err := pipe.Persist(ctx, depKey).Err(); err != nil {
-			return xerrors.Errorf("Failed to remove the existing timeout on Key. err: %w", err)
-		}
 	}
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)


### PR DESCRIPTION
# What did you implement:
Expire was introduced to ensure safe operation in Redis, but since expire can only be set per key, it is not very useful for Sets and Hash.
Therefore, if there is any old content in each fetch, it will be deleted.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

