### PR TITLE
fix(redis): pipe cannot take err except for pipe.Exec

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -330,17 +330,13 @@ func (r *RedisDriver) InsertExploit(exploitType models.ExploitType, exploits []m
 				return xerrors.Errorf("Failed to marshal json. err: %w", err)
 			}
 
-			if err := pipe.HSet(ctx, fmt.Sprintf(exploitDBIDKeyFormat, exploit.ExploitUniqueID), exploit.CveID, string(j)).Err(); err != nil {
-				return xerrors.Errorf("Failed to HSet Exploit. err: %w", err)
-			}
+			_ = pipe.HSet(ctx, fmt.Sprintf(exploitDBIDKeyFormat, exploit.ExploitUniqueID), exploit.CveID, string(j))
 			if _, ok := newDeps[exploit.ExploitUniqueID]; !ok {
 				newDeps[exploit.ExploitUniqueID] = map[string]struct{}{}
 			}
 
 			if exploit.CveID != "" {
-				if err := pipe.SAdd(ctx, fmt.Sprintf(cveIDKeyFormat, exploit.CveID), exploit.ExploitUniqueID).Err(); err != nil {
-					return xerrors.Errorf("Failed to SAdd CVE. err: %w", err)
-				}
+				_ = pipe.SAdd(ctx, fmt.Sprintf(cveIDKeyFormat, exploit.CveID), exploit.ExploitUniqueID)
 				cveIDExploitCount++
 			} else {
 				noCveIDExploitCount++
@@ -365,22 +361,16 @@ func (r *RedisDriver) InsertExploit(exploitType models.ExploitType, exploits []m
 	for eid, cves := range oldDeps {
 		for cveid := range cves {
 			if cveid != "" {
-				if err := pipe.SRem(ctx, fmt.Sprintf(cveIDKeyFormat, cveid), eid).Err(); err != nil {
-					return xerrors.Errorf("Failed to SRem. err: %w", err)
-				}
+				_ = pipe.SRem(ctx, fmt.Sprintf(cveIDKeyFormat, cveid), eid)
 			}
-			if err := pipe.HDel(ctx, fmt.Sprintf(exploitDBIDKeyFormat, eid), cveid).Err(); err != nil {
-				return xerrors.Errorf("Failed to HDel. err: %w", err)
-			}
+			_ = pipe.HDel(ctx, fmt.Sprintf(exploitDBIDKeyFormat, eid), cveid)
 		}
 	}
 	newDepsJSON, err := json.Marshal(newDeps)
 	if err != nil {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
-	if err := pipe.HSet(ctx, depKey, string(exploitType), string(newDepsJSON)).Err(); err != nil {
-		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
-	}
+	_ = pipe.HSet(ctx, depKey, string(exploitType), string(newDepsJSON))
 	if _, err = pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}


### PR DESCRIPTION
# What did you implement:
Since pipe can't get err except for pipe.Exec, I modified the code.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

