### PR TITLE
feat(db): add LastFetchedDate in fetchmeta

### DIFF
--- a/commands/fetch-awesomepoc.go
+++ b/commands/fetch-awesomepoc.go
@@ -66,7 +66,7 @@ func fetchAwesomePoc(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/commands/fetch-awesomepoc.go
+++ b/commands/fetch-awesomepoc.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -37,7 +39,7 @@ func fetchAwesomePoc(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -45,9 +47,9 @@ func fetchAwesomePoc(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
@@ -62,6 +64,11 @@ func fetchAwesomePoc(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
 	if err := driver.InsertExploit(models.AwesomePocType, exploits); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/commands/fetch-exploitdb.go
+++ b/commands/fetch-exploitdb.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -37,7 +39,7 @@ func fetchExploitDB(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -45,9 +47,9 @@ func fetchExploitDB(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
@@ -62,6 +64,11 @@ func fetchExploitDB(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
 	if err := driver.InsertExploit(models.OffensiveSecurityType, exploits); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/commands/fetch-exploitdb.go
+++ b/commands/fetch-exploitdb.go
@@ -66,7 +66,7 @@ func fetchExploitDB(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/commands/fetch-githubrepos.go
+++ b/commands/fetch-githubrepos.go
@@ -72,7 +72,7 @@ func fetchGitHubRepos(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}

--- a/commands/fetch-githubrepos.go
+++ b/commands/fetch-githubrepos.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -43,7 +45,7 @@ func fetchGitHubRepos(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -51,9 +53,9 @@ func fetchGitHubRepos(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
@@ -68,6 +70,11 @@ func fetchGitHubRepos(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
 	if err := driver.InsertExploit(models.GitHubRepositoryType, exploits); err != nil {
 		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
 	}
 
 	return nil

--- a/commands/search.go
+++ b/commands/search.go
@@ -52,7 +52,15 @@ func searchExploit(cmd *cobra.Command, args []string) error {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
+	}
+
+	fetchMeta, err := driver.GetFetchMeta()
+	if err != nil {
+		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
+	}
+	if fetchMeta.OutDated() {
+		return xerrors.Errorf("Failed to search command. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	searchType := viper.GetString("type")

--- a/commands/server.go
+++ b/commands/server.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vulsio/go-exploitdb/db"
+	"github.com/vulsio/go-exploitdb/models"
 	server "github.com/vulsio/go-exploitdb/server"
 	"github.com/vulsio/go-exploitdb/util"
 	"golang.org/x/xerrors"
@@ -41,7 +42,15 @@ func executeServer(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
+	}
+
+	fetchMeta, err := driver.GetFetchMeta()
+	if err != nil {
+		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
+	}
+	if fetchMeta.OutDated() {
+		return xerrors.Errorf("Failed to start server. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	log15.Info("Starting HTTP Server...")

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -367,7 +367,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{ExploitRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{ExploitRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -367,7 +367,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{ExploitRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
+		return &models.FetchMeta{ExploitRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/redis.go
+++ b/db/redis.go
@@ -28,20 +28,20 @@ import (
   └───┴────────────────┴──────────────┴───────────────────────────┘
 
 - Hash
-  ┌───┬──────────────────────┬─────────────────┬───────────────┬───────────────────────────────────────────────────┐
-  │NO │    KEY               │   FIELD         │  VALUE        │       PURPOSE                                     │
-  └───┴──────────────────────┴─────────────────┴───────────────┴───────────────────────────────────────────────────┘
-  ┌───┬──────────────────────┬─────────────────┬───────────────┬───────────────────────────────────────────────────┐
-  │ 1 │ EDB#EDB#$EXPLOITDBID │    $CVEID       │ $EXPLOIT JSON │ TO GET EXPLOIT FROM EXPLOITDBID                   │
-  ├───┼──────────────────────┼─────────────────┼───────────────┼───────────────────────────────────────────────────┤
-  │ 2 │ EDB#DEP              │ $EXPLOITTYPE    │     JSON      │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER  │
-  ├───┼──────────────────────┼─────────────────┼───────────────┼───────────────────────────────────────────────────┤
-  │ 3 │ EDB#FETCHMETA        │   Revision      │    string     │ GET GO-EXPLOIT BINARY REVISION                    │
-  ├───┼──────────────────────┼─────────────────┼───────────────┼───────────────────────────────────────────────────┤
-  │ 4 │ EDB#FETCHMETA        │ SchemaVersion   │     uint      │ GET GO-EXPLOIT SCHEMA VERSION                     │
-  ├───┼──────────────────────┼─────────────────┼───────────────┼───────────────────────────────────────────────────┤
-  │ 5 │ EDB#FETCHMETA        │ LastFetchedDate │   time.Time   │ GET GO-EXPLOIT LAST FETCHED TIME                  │
-  └───┴──────────────────────┴─────────────────┴───────────────┴───────────────────────────────────────────────────┘
+  ┌───┬──────────────────────┬───────────────┬───────────────┬───────────────────────────────────────────────────┐
+  │NO │    KEY               │   FIELD       │  VALUE        │       PURPOSE                                     │
+  └───┴──────────────────────┴───────────────┴───────────────┴───────────────────────────────────────────────────┘
+  ┌───┬──────────────────────┬───────────────┬───────────────┬───────────────────────────────────────────────────┐
+  │ 1 │ EDB#EDB#$EXPLOITDBID │    $CVEID     │ $EXPLOIT JSON │ TO GET EXPLOIT FROM EXPLOITDBID                   │
+  ├───┼──────────────────────┼───────────────┼───────────────┼───────────────────────────────────────────────────┤
+  │ 2 │ EDB#DEP              │ $EXPLOITTYPE  │     JSON      │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER  │
+  ├───┼──────────────────────┼───────────────┼───────────────┼───────────────────────────────────────────────────┤
+  │ 3 │ EDB#FETCHMETA        │   Revision    │    string     │ GET GO-EXPLOIT BINARY REVISION                    │
+  ├───┼──────────────────────┼───────────────┼───────────────┼───────────────────────────────────────────────────┤
+  │ 4 │ EDB#FETCHMETA        │ SchemaVersion │     uint      │ GET GO-EXPLOIT SCHEMA VERSION                     │
+  ├───┼──────────────────────┼───────────────┼───────────────┼───────────────────────────────────────────────────┤
+  │ 5 │ EDB#FETCHMETA        │ LastFetchedAt │   time.Time   │ GET GO-EXPLOIT LAST FETCHED TIME                  │
+  └───┴──────────────────────┴───────────────┴───────────────┴───────────────────────────────────────────────────┘
 **/
 
 const (
@@ -424,7 +424,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
-		return &models.FetchMeta{ExploitRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{ExploitRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
@@ -441,10 +441,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
-	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
+	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedAt").Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedAt. err: %w", err)
 		}
 		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
@@ -453,10 +453,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Parse date. err: %w", err)
 	}
 
-	return &models.FetchMeta{ExploitRevision: revision, SchemaVersion: uint(version), LastFetchedDate: date}, nil
+	return &models.FetchMeta{ExploitRevision: revision, SchemaVersion: uint(version), LastFetchedAt: date}, nil
 }
 
 // UpsertFetchMeta upsert FetchMeta to Database
 func (r *RedisDriver) UpsertFetchMeta(fetchMeta *models.FetchMeta) error {
-	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedDate": fetchMeta.LastFetchedDate}).Err()
+	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedAt": fetchMeta.LastFetchedAt}).Err()
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -443,7 +443,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 
 	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		if !errors.Is(err, redis.Nil) {
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		}
+		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
 	date, err := time.Parse(time.RFC3339, datestr)
 	if err != nil {

--- a/db/redis.go
+++ b/db/redis.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/go-redis/redis/v8"
@@ -27,18 +28,20 @@ import (
   └───┴────────────────┴──────────────┴───────────────────────────┘
 
 - Hash
-  ┌───┬──────────────────────┬───────────────┬───────────────┬───────────────────────────────────────────────────┐
-  │NO │    KEY               │   FIELD       │  VALUE        │       PURPOSE                                     │
-  └───┴──────────────────────┴───────────────┴───────────────┴───────────────────────────────────────────────────┘
-  ┌───┬──────────────────────┬───────────────┬───────────────┬───────────────────────────────────────────────────┐
-  │ 1 │ EDB#EDB#$EXPLOITDBID │    $CVEID     │ $EXPLOIT JSON │ TO GET EXPLOIT FROM EXPLOITDBID                   │
-  ├───┼──────────────────────┼───────────────┼───────────────┼───────────────────────────────────────────────────┤
-  │ 2 │ EDB#DEP              │ $EXPLOITTYPE  │     JSON      │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER  │
-  ├───┼──────────────────────┼───────────────┼───────────────┼───────────────────────────────────────────────────┤
-  │ 3 │ EDB#FETCHMETA        │   Revision    │    string     │ GET GO-EXPLOIT BINARY REVISION                    │
-  ├───┼──────────────────────┼───────────────┼───────────────┼───────────────────────────────────────────────────┤
-  │ 4 │ EDB#FETCHMETA        │ SchemaVersion │     uint      │ GET GO-EXPLOIT SCHEMA VERSION                     │
-  └───┴──────────────────────┴───────────────┴───────────────┴───────────────────────────────────────────────────┘
+  ┌───┬──────────────────────┬─────────────────┬───────────────┬───────────────────────────────────────────────────┐
+  │NO │    KEY               │   FIELD         │  VALUE        │       PURPOSE                                     │
+  └───┴──────────────────────┴─────────────────┴───────────────┴───────────────────────────────────────────────────┘
+  ┌───┬──────────────────────┬─────────────────┬───────────────┬───────────────────────────────────────────────────┐
+  │ 1 │ EDB#EDB#$EXPLOITDBID │    $CVEID       │ $EXPLOIT JSON │ TO GET EXPLOIT FROM EXPLOITDBID                   │
+  ├───┼──────────────────────┼─────────────────┼───────────────┼───────────────────────────────────────────────────┤
+  │ 2 │ EDB#DEP              │ $EXPLOITTYPE    │     JSON      │ TO DELETE OUTDATED AND UNNEEDED FIELD AND MEMBER  │
+  ├───┼──────────────────────┼─────────────────┼───────────────┼───────────────────────────────────────────────────┤
+  │ 3 │ EDB#FETCHMETA        │   Revision      │    string     │ GET GO-EXPLOIT BINARY REVISION                    │
+  ├───┼──────────────────────┼─────────────────┼───────────────┼───────────────────────────────────────────────────┤
+  │ 4 │ EDB#FETCHMETA        │ SchemaVersion   │     uint      │ GET GO-EXPLOIT SCHEMA VERSION                     │
+  ├───┼──────────────────────┼─────────────────┼───────────────┼───────────────────────────────────────────────────┤
+  │ 5 │ EDB#FETCHMETA        │ LastFetchedDate │   time.Time   │ GET GO-EXPLOIT LAST FETCHED TIME                  │
+  └───┴──────────────────────┴─────────────────┴───────────────┴───────────────────────────────────────────────────┘
 **/
 
 const (
@@ -421,7 +424,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
-		return &models.FetchMeta{ExploitRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
+		return &models.FetchMeta{ExploitRevision: config.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
@@ -438,10 +441,19 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
-	return &models.FetchMeta{ExploitRevision: revision, SchemaVersion: uint(version)}, nil
+	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+	}
+	date, err := time.Parse(time.RFC3339, datestr)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to Parse date. err: %w", err)
+	}
+
+	return &models.FetchMeta{ExploitRevision: revision, SchemaVersion: uint(version), LastFetchedDate: date}, nil
 }
 
 // UpsertFetchMeta upsert FetchMeta to Database
 func (r *RedisDriver) UpsertFetchMeta(fetchMeta *models.FetchMeta) error {
-	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": fetchMeta.ExploitRevision, "SchemaVersion": fetchMeta.SchemaVersion}).Err()
+	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": config.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedDate": fetchMeta.LastFetchedDate}).Err()
 }

--- a/models/models.go
+++ b/models/models.go
@@ -1,6 +1,10 @@
 package models
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // LatestSchemaVersion manages the Schema version used in the latest go-exploitdb.
 const LatestSchemaVersion = 2
@@ -10,6 +14,7 @@ type FetchMeta struct {
 	gorm.Model      `json:"-"`
 	ExploitRevision string
 	SchemaVersion   uint
+	LastFetchedDate time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated

--- a/models/models.go
+++ b/models/models.go
@@ -14,7 +14,7 @@ type FetchMeta struct {
 	gorm.Model      `json:"-"`
 	ExploitRevision string
 	SchemaVersion   uint
-	LastFetchedDate time.Time
+	LastFetchedAt   time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated


### PR DESCRIPTION
# What did you implement:
Add the time when the fetch is completed to fetchmeta.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## RDB
```console
$ go-exploitdb fetch awesomepoc
$ sqlite3 go-exploitdb.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 10:05:14.90520975+09:00

$ go-exploitdb fetch awesomepoc
$ sqlite3 go-exploitdb.sqlite3 
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 10:05:35.710005779+09:00
```

## Redis
```console
$ redis-cli -p 6379
127.0.0.1:6379> HGET EDB#FETCHMETA LastFetchedAt
(nil)

$ go-exploitdb fetch awesomepoc --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET EDB#FETCHMETA LastFetchedAt
"2021-12-26T10:06:09.012298276+09:00"

$ go-exploitdb fetch awesomepoc --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET EDB#FETCHMETA LastFetchedAt
"2021-12-26T10:06:27.19301146+09:00"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
