### PR TITLE
feat(inthewild): support inTheWild PoCs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -90,10 +90,12 @@ fetch-rdb:
 	integration/exploitdb.old fetch awesomepoc --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
 	integration/exploitdb.old fetch exploitdb --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
 	integration/exploitdb.old fetch githubrepos --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
+	integration/exploitdb.old fetch inthewild --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
 
 	integration/exploitdb.new fetch awesomepoc --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
 	integration/exploitdb.new fetch exploitdb --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
 	integration/exploitdb.new fetch githubrepos --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
+	integration/exploitdb.new fetch inthewild --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
 
 fetch-redis:
 	docker run --name redis-old -d -p 127.0.0.1:6379:6379 redis
@@ -102,10 +104,12 @@ fetch-redis:
 	integration/exploitdb.old fetch awesomepoc --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
 	integration/exploitdb.old fetch exploitdb --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
 	integration/exploitdb.old fetch githubrepos --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
+	integration/exploitdb.old fetch inthewild --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
 
 	integration/exploitdb.new fetch awesomepoc --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
 	integration/exploitdb.new fetch exploitdb --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
 	integration/exploitdb.new fetch githubrepos --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
+	integration/exploitdb.new fetch inthewild --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
 
 diff-cveid:
 	@ python integration/diff_server_mode.py cveid --sample_rate 0.01

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ As the following vulnerabilities database
 1. [ExploitDB(OffensiveSecurity)](https://www.exploit-db.com/) by CVE number or Exploit Database ID.
 2. [GitHub Repositories](https://github.com/search?o=desc&q=CVE&s=&type=Repositories)
 3. [Awesome Cve Poc](https://github.com/qazbnm456/awesome-cve-poc#toc473)
+4. [inTheWild DB](https://github.com/gmatuz/inthewilddb)
 
 ### Docker Deployment
-There's a Docker image available `docker pull princechrismc/go-exploitdb`. When using the container, it takes the same arguments as the [normal command line](#Usage).
+There's a Docker image available `docker pull vulsio/go-exploitdb`. When using the container, it takes the same arguments as the [normal command line](#Usage).
 
 ### Installation for local deployment
 ###### Requirements
@@ -54,6 +55,7 @@ Available Commands:
   awesomepoc  Fetch the data of Awesome Poc
   exploitdb   Fetch the data of offensive security exploit db
   githubrepos Fetch the data of github repos
+  inthewild   Fetch the data of inTheWild Poc
 
 Flags:
       --batch-size int   The number of batch size to insert. (default 500)

--- a/commands/fetch-inthewild.go
+++ b/commands/fetch-inthewild.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/xerrors"
+
+	"github.com/vulsio/go-exploitdb/db"
+	"github.com/vulsio/go-exploitdb/fetcher"
+	"github.com/vulsio/go-exploitdb/models"
+	"github.com/vulsio/go-exploitdb/util"
+)
+
+var fetchInTheWildCmd = &cobra.Command{
+	Use:   "inthewild",
+	Short: "Fetch the data of inTheWild Poc",
+	Long:  `Fetch the data of inTheWild Poc`,
+	RunE:  fetchInTheWild,
+}
+
+func init() {
+	fetchCmd.AddCommand(fetchInTheWildCmd)
+}
+
+func fetchInTheWild(_ *cobra.Command, _ []string) (err error) {
+	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
+		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
+	}
+
+	driver, locked, err := db.NewDB(
+		viper.GetString("dbtype"),
+		viper.GetString("dbpath"),
+		viper.GetBool("debug-sql"),
+		db.Option{},
+	)
+	if err != nil {
+		if locked {
+			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
+		}
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
+	}
+
+	fetchMeta, err := driver.GetFetchMeta()
+	if err != nil {
+		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
+	}
+	if fetchMeta.OutDated() {
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+	}
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	log15.Info("Fetching inTheWild Poc Exploit")
+	var exploits []models.Exploit
+	if exploits, err = fetcher.FetchInTheWild(viper.GetBool("debug-sql")); err != nil {
+		return xerrors.Errorf("Failed to fetch InTheWild Exploit. err: %w", err)
+	}
+	log15.Info("inTheWild Poc Exploit", "count", len(exploits))
+
+	log15.Info("Insert Exploit into go-exploitdb.", "db", driver.Name())
+	if err := driver.InsertExploit(models.InTheWildType, exploits); err != nil {
+		return xerrors.Errorf("Failed to insert. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	fetchMeta.LastFetchedAt = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. dbpath: %s, err: %w", viper.GetString("dbpath"), err)
+	}
+
+	return nil
+}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -118,6 +118,7 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.ShellCode{},
 		&models.Paper{},
 		&models.GitHubRepository{},
+		&models.InTheWild{},
 	); err != nil {
 		return xerrors.Errorf("Failed to migrate. err: %w", err)
 	}
@@ -171,6 +172,16 @@ func (r *RDBDriver) deleteAndInsertExploit(exploitType models.ExploitType, explo
 			}
 			if len(ghIDs) > 0 {
 				if err := tx.Where("id IN ?", ghIDs).Delete(&models.GitHubRepository{}).Error; err != nil {
+					return xerrors.Errorf("Failed to delete: %w", err)
+				}
+			}
+
+			itwIDs := []models.InTheWild{}
+			if err := tx.Model(&models.InTheWild{}).Select("id").Where("exploit_id IN ?", oldIDs[idx.From:idx.To]).Find(&osIDs).Error; err != nil {
+				return xerrors.Errorf("Failed to select old inTheWild: %w", err)
+			}
+			if len(itwIDs) > 0 {
+				if err := tx.Where("id IN ?", itwIDs).Delete(&models.InTheWild{}).Error; err != nil {
 					return xerrors.Errorf("Failed to delete: %w", err)
 				}
 			}
@@ -231,6 +242,13 @@ func (r *RDBDriver) GetExploitByID(exploitUniqueID string) ([]models.Exploit, er
 				}
 				return nil, xerrors.Errorf("Failed to get GitHubRepository. err: %w", err)
 			}
+		case models.InTheWildType:
+			if err := r.conn.Where(&models.InTheWild{ExploitID: es[i].ID}).Take(&es[i].InTheWild).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get inTheWild. DB relationship may be broken, use `$ go-exploitdb fetch inthewild` to recreate DB. err: %w", err)
+				}
+				return nil, xerrors.Errorf("Failed to get inTheWild. err: %w", err)
+			}
 		}
 	}
 	return es, nil
@@ -268,6 +286,13 @@ func (r *RDBDriver) GetExploitAll() ([]models.Exploit, error) {
 					return nil, xerrors.Errorf("Failed to get GitHubRepository. DB relationship may be broken, use `$ go-exploitdb fetch githubrepos` to recreate DB. err: %w", err)
 				}
 				return nil, xerrors.Errorf("Failed to Get GitHubRepository. err: %w", err)
+			}
+		case models.InTheWildType:
+			if err := r.conn.Where(&models.InTheWild{ExploitID: exploit.ID}).Take(&exploit.InTheWild).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get inTheWild. DB relationship may be broken, use `$ go-exploitdb fetch inthewild` to recreate DB. err: %w", err)
+				}
+				return nil, xerrors.Errorf("Failed to Get inTheWild. err: %w", err)
 			}
 		}
 		es = append(es, exploit)
@@ -315,6 +340,13 @@ func (r *RDBDriver) GetExploitByCveID(cveID string) ([]models.Exploit, error) {
 					return nil, xerrors.Errorf("Failed to get GitHubRepository. DB relationship may be broken, use `$ go-exploitdb fetch githubrepos` to recreate DB. err: %w", err)
 				}
 				return nil, xerrors.Errorf("Failed to get GitHubRepository. err: %w", err)
+			}
+		case models.InTheWildType:
+			if err := r.conn.Where(&models.InTheWild{ExploitID: es[i].ID}).Take(&es[i].InTheWild).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, xerrors.Errorf("Failed to get inTheWild. DB relationship may be broken, use `$ go-exploitdb fetch inthewild` to recreate DB. err: %w", err)
+				}
+				return nil, xerrors.Errorf("Failed to get inTheWild. err: %w", err)
 			}
 		}
 	}

--- a/fetcher/awesomepoc.go
+++ b/fetcher/awesomepoc.go
@@ -96,7 +96,7 @@ func FetchAwesomePoc() (exploits []models.Exploit, err error) {
 	for poc := range r.AwesomePoc {
 		exploit := models.Exploit{
 			ExploitType:     models.AwesomePocType,
-			ExploitUniqueID: fmt.Sprintf("%s-%x", models.AwesomePocType, md5.Sum([]byte(poc.URL))),
+			ExploitUniqueID: fmt.Sprintf("%s-%x", models.AwesomePocType, md5.Sum([]byte(poc.CveID+poc.URL))),
 			URL:             poc.URL,
 			Description:     poc.Description,
 			CveID:           poc.CveID,

--- a/fetcher/githubrepos.go
+++ b/fetcher/githubrepos.go
@@ -76,9 +76,8 @@ func FetchGitHubRepos(stars, forks int) (exploits []models.Exploit, err error) {
 				continue
 			}
 
-			eid := fmt.Sprintf("%s-%x", models.GitHubRepositoryType, md5.Sum([]byte(poc.URL)))
 			githubRepoExploit := models.Exploit{
-				ExploitUniqueID: eid,
+				ExploitUniqueID: fmt.Sprintf("%s-%x", models.GitHubRepositoryType, md5.Sum([]byte(cveID+poc.URL))),
 				ExploitType:     models.GitHubRepositoryType,
 				URL:             poc.URL,
 				CveID:           cveID,

--- a/fetcher/inthewild.go
+++ b/fetcher/inthewild.go
@@ -1,0 +1,128 @@
+package fetcher
+
+import (
+	"bytes"
+	"crypto/md5"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/xerrors"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/vulsio/go-exploitdb/models"
+	"github.com/vulsio/go-exploitdb/util"
+)
+
+// https://www.sqlite.org/fileformat.html
+var sqlite3HeaderMagic = []byte("SQLite format 3\x00")
+
+const dbURL string = "https://github.com/gmatuz/inthewilddb/blob/master/inthewild.db?raw=true"
+
+type exploit struct {
+	CVEID        string         `gorm:"column:exploits.id"`
+	Description  sql.NullString `gorm:"column:vulns.description"`
+	ReferenceURL string         `gorm:"column:exploits.referenceURL"`
+	TimeStamp    time.Time      `gorm:"column:exploits.timestamp"`
+	Source       string         `gorm:"column:exploits.source"`
+	Type         string         `gorm:"column:exploits.type"`
+}
+
+// FetchInTheWild :
+func FetchInTheWild(debugSQL bool) ([]models.Exploit, error) {
+	if err := os.MkdirAll(util.CacheDir(), 0700); err != nil {
+		return nil, xerrors.Errorf("Failed to mkdir: %w", err)
+	}
+	dbPath := filepath.Join(util.CacheDir(), "inthewild.db")
+	f, err := os.Create(dbPath)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to create inthewild.db in cache directory. err: %w", err)
+	}
+	defer f.Close()
+
+	res, err := util.FetchURL(dbURL)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to fetch inTheWild DB. err: %w", err)
+	}
+	if !bytes.Equal(res[:16], sqlite3HeaderMagic) {
+		return nil, xerrors.Errorf("Failed to fetch inTheWild DB. err: not sqlite3 database")
+	}
+	if n, err := f.Write(res); err != nil {
+		return nil, xerrors.Errorf("Failed to write db. err: %w", err)
+	} else if n != len(res) {
+		return nil, xerrors.Errorf("Failed to write db. err: not enough bytes written")
+	}
+
+	gormConfig := gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+		Logger: logger.New(
+			log.New(os.Stderr, "\r\n", log.LstdFlags),
+			logger.Config{
+				LogLevel: logger.Silent,
+			},
+		),
+	}
+
+	if debugSQL {
+		gormConfig.Logger = logger.New(
+			log.New(os.Stderr, "\r\n", log.LstdFlags),
+			logger.Config{
+				SlowThreshold: time.Second,
+				LogLevel:      logger.Info,
+				Colorful:      true,
+			},
+		)
+	}
+	db, err := gorm.Open(sqlite.Open(dbPath), &gormConfig)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to open inTheWild DB. err: %w", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to get DB Object. err : %w", err)
+	}
+	defer sqlDB.Close()
+
+	rows, err := db.
+		Table("exploits").
+		Select("exploits.id, vulns.description, exploits.referenceURL, exploits.timestamp, exploits.source, exploits.type").
+		Joins("LEFT JOIN vulns ON vulns.id = exploits.id").
+		Rows()
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to select exploits. err: %w", err)
+	}
+	defer rows.Close()
+
+	exploits := []models.Exploit{}
+	var exploit exploit
+	for rows.Next() {
+		if err := rows.Scan(&exploit.CVEID, &exploit.Description, &exploit.ReferenceURL, &exploit.TimeStamp, &exploit.Source, &exploit.Type); err != nil {
+			return nil, xerrors.Errorf("Failed to scan rows. err: %w", err)
+		}
+
+		// manually correct CVE-ID. ref: https://github.com/gmatuz/inthewilddb/issues/6
+		if exploit.CVEID == "CVE 2020-12271" {
+			exploit.CVEID = "CVE-2020-12271"
+		}
+
+		exploits = append(exploits, models.Exploit{
+			ExploitType:     models.InTheWildType,
+			ExploitUniqueID: fmt.Sprintf("%s-%x", models.InTheWildType, md5.Sum([]byte(exploit.CVEID+exploit.ReferenceURL+exploit.Source+exploit.Type))),
+			URL:             exploit.ReferenceURL,
+			Description:     exploit.Description.String,
+			CveID:           exploit.CVEID,
+			InTheWild: &models.InTheWild{
+				TimeStamp: exploit.TimeStamp,
+				Source:    exploit.Source,
+				Type:      exploit.Type,
+			},
+		})
+	}
+
+	return exploits, nil
+}

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -17,6 +17,8 @@ var (
 	GitHubRepositoryType ExploitType = "GitHub"
 	// AwesomePocType :
 	AwesomePocType ExploitType = "AwesomePoc"
+	// InTheWildType :
+	InTheWildType ExploitType = "InTheWild"
 )
 
 // Exploit :
@@ -29,6 +31,7 @@ type Exploit struct {
 	CveID             string             `gorm:"type:varchar(255);index:idx_exploit_cve_id" json:"cve_id"`
 	OffensiveSecurity *OffensiveSecurity `json:"offensive_security"`
 	GitHubRepository  *GitHubRepository  `json:"github_repository"`
+	InTheWild         *InTheWild         `json:"in_the_wild"`
 }
 
 // GitHubRepository :
@@ -92,6 +95,15 @@ type Paper struct {
 	Type                string                `gorm:"type:varchar(255)" csv:"type" json:"type"`
 	Platform            string                `gorm:"type:varchar(255)" csv:"platform" json:"platform"`
 	Language            string                `gorm:"type:varchar(255)" csv:"language" json:"language"`
+}
+
+// InTheWild :
+type InTheWild struct {
+	ID        int64     `json:"-"`
+	ExploitID int64     `gorm:"index:idx_in_the_wild_exploit_id" json:"-"`
+	TimeStamp time.Time `json:"timestamp"`
+	Source    string    `gorm:"type:varchar(255)" json:"source"`
+	Type      string    `gorm:"type:varchar(255)" json:"type"`
 }
 
 // MitreXML :


### PR DESCRIPTION
# What did you implement:

Fixes https://github.com/vulsio/go-kev/issues/5

Add inTheWild as a new data source.
https://github.com/gmatuz/inthewilddb

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## fetch
```console
$ go-exploitdb fetch inthewild
INFO[02-18|06:36:56] Fetching inTheWild Poc Exploit 
INFO[02-18|06:36:58] inTheWild Poc Exploit                    count=70378
INFO[02-18|06:36:58] Insert Exploit into go-exploitdb.        db=sqlite3
INFO[02-18|06:36:58] Inserting 70378 Exploits 
INFO[02-18|06:36:58] Inserting new Exploits 
70378 / 70378 [-------------------------------------------------------------------------------------------------------] 100.00% 162670 p/s
INFO[02-18|06:36:58] No CveID Exploit Count                   count=0
INFO[02-18|06:36:58] CveID Exploit Count                      count=70378

$ wget "https://github.com/gmatuz/inthewilddb/blob/master/inthewild.db?raw=true" -O inthewild.db
$ sqlite3 inthewild.db
sqlite> SELECT COUNT(id) FROM exploits;
70378

$ sqlite3 go-exploitdb.sqlite3
sqlite> SELECT count(exploit_unique_id) FROM exploits;
70378
sqlite> SELECT count(DISTINCT(exploit_unique_id)) FROM exploits;
70378
```
## diff test
```console
$ patch -p1 < test.patch
$ make clean-integration && make build-integration
$ make fetch-rdb && make fetch-redis
$ make diff-server-rdb-redis
```

- test.patch
```diff
diff --git a/GNUmakefile b/GNUmakefile
index ec24e54..2f82cca 100644
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -70,13 +70,13 @@ clean:
 PWD := $(shell pwd)
 BRANCH := $(shell git symbolic-ref --short HEAD)
 build-integration:
-	@ git stash save
+	# @ git stash save
 	$(GO) build -ldflags "$(LDFLAGS)" -o integration/exploitdb.new
-	git checkout $(shell git describe --tags --abbrev=0)
-	@git reset --hard
-	$(GO) build -ldflags "$(LDFLAGS)" -o integration/exploitdb.old
-	git checkout $(BRANCH)
-	@ git stash apply stash@{0} && git stash drop stash@{0}
+	# git checkout $(shell git describe --tags --abbrev=0)
+	# @git reset --hard
+	# $(GO) build -ldflags "$(LDFLAGS)" -o integration/exploitdb.old
+	# git checkout $(BRANCH)
+	# @ git stash apply stash@{0} && git stash drop stash@{0}
 
 clean-integration:
 	-pkill exploitdb.old
@@ -87,28 +87,28 @@ clean-integration:
 	-docker rm redis-old redis-new
 
 fetch-rdb:
-	integration/exploitdb.old fetch awesomepoc --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
-	integration/exploitdb.old fetch exploitdb --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
-	integration/exploitdb.old fetch githubrepos --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
-	integration/exploitdb.old fetch inthewild --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
-
-	integration/exploitdb.new fetch awesomepoc --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
-	integration/exploitdb.new fetch exploitdb --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
-	integration/exploitdb.new fetch githubrepos --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
+	# integration/exploitdb.old fetch awesomepoc --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
+	# integration/exploitdb.old fetch exploitdb --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
+	# integration/exploitdb.old fetch githubrepos --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
+	# integration/exploitdb.old fetch inthewild --dbpath=$(PWD)/integration/go-exploitdb.old.sqlite3
+
+	# integration/exploitdb.new fetch awesomepoc --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
+	# integration/exploitdb.new fetch exploitdb --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
+	# integration/exploitdb.new fetch githubrepos --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
 	integration/exploitdb.new fetch inthewild --dbpath=$(PWD)/integration/go-exploitdb.new.sqlite3
 
 fetch-redis:
-	docker run --name redis-old -d -p 127.0.0.1:6379:6379 redis
+	# docker run --name redis-old -d -p 127.0.0.1:6379:6379 redis
 	docker run --name redis-new -d -p 127.0.0.1:6380:6379 redis
 	
-	integration/exploitdb.old fetch awesomepoc --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
-	integration/exploitdb.old fetch exploitdb --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
-	integration/exploitdb.old fetch githubrepos --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
-	integration/exploitdb.old fetch inthewild --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
-
-	integration/exploitdb.new fetch awesomepoc --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
-	integration/exploitdb.new fetch exploitdb --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
-	integration/exploitdb.new fetch githubrepos --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
+	# integration/exploitdb.old fetch awesomepoc --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
+	# integration/exploitdb.old fetch exploitdb --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
+	# integration/exploitdb.old fetch githubrepos --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
+	# integration/exploitdb.old fetch inthewild --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
+
+	# integration/exploitdb.new fetch awesomepoc --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
+	# integration/exploitdb.new fetch exploitdb --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
+	# integration/exploitdb.new fetch githubrepos --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
 	integration/exploitdb.new fetch inthewild --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
 
 diff-cveid:

```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

