### PR TITLE
fix(fetcher/exploitdb): fill in nil even if Document etc. is not found

### DIFF
--- a/fetcher/exploitdb.go
+++ b/fetcher/exploitdb.go
@@ -385,17 +385,19 @@ func joinExploits(toCVEs map[string][]string, toDocument map[string]models.Docum
 		if len(cves) > 0 {
 			for _, cve := range cves {
 				toExploits[id] = append(toExploits[id], models.Exploit{
-					ExploitType:     models.OffensiveSecurityType,
-					ExploitUniqueID: id,
-					URL:             fmt.Sprintf("https://www.exploit-db.com/exploits/%s", id),
-					CveID:           cve,
+					ExploitType:       models.OffensiveSecurityType,
+					ExploitUniqueID:   id,
+					URL:               fmt.Sprintf("https://www.exploit-db.com/exploits/%s", id),
+					CveID:             cve,
+					OffensiveSecurity: &models.OffensiveSecurity{},
 				})
 			}
 		} else {
 			toExploits[id] = append(toExploits[id], models.Exploit{
-				ExploitType:     models.OffensiveSecurityType,
-				ExploitUniqueID: id,
-				URL:             fmt.Sprintf("https://www.exploit-db.com/exploits/%s", id),
+				ExploitType:       models.OffensiveSecurityType,
+				ExploitUniqueID:   id,
+				URL:               fmt.Sprintf("https://www.exploit-db.com/exploits/%s", id),
+				OffensiveSecurity: &models.OffensiveSecurity{},
 			})
 		}
 	}
@@ -548,9 +550,6 @@ func joinExploits(toCVEs map[string][]string, toDocument map[string]models.Docum
 			continue
 		}
 		for i := range es {
-			if es[i].OffensiveSecurity == nil {
-				es[i].OffensiveSecurity = &models.OffensiveSecurity{}
-			}
 			es[i].OffensiveSecurity.GHDB = &models.GHDB{
 				Link:               ghdb.Link,
 				Category:           ghdb.Category,

--- a/fetcher/exploitdb_test.go
+++ b/fetcher/exploitdb_test.go
@@ -81,10 +81,11 @@ func Test_joinExploits(t *testing.T) {
 			},
 			want: []models.Exploit{
 				{
-					ExploitType:     models.OffensiveSecurityType,
-					ExploitUniqueID: "0",
-					URL:             "https://www.exploit-db.com/exploits/0",
-					CveID:           "CVE-0000-0000",
+					ExploitType:       models.OffensiveSecurityType,
+					ExploitUniqueID:   "0",
+					URL:               "https://www.exploit-db.com/exploits/0",
+					CveID:             "CVE-0000-0000",
+					OffensiveSecurity: &models.OffensiveSecurity{},
 				},
 				{
 					ExploitType:     models.OffensiveSecurityType,

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -51,6 +51,7 @@ type OffensiveSecurity struct {
 	GHDB      *GHDB      `json:"ghdb,omitempty"`
 }
 
+// Base :
 type Base struct {
 	FileURL        string     `gorm:"type:varchar(255)" json:"file_url"`
 	Description    string     `gorm:"type:text" json:"description"`


### PR DESCRIPTION
# What did you implement:

If the Document provided to gitlab cannot be found, `Exploit.OffensiveSecurity` will be nil.
If you try to search for such an exploit, you will get an error that it cannot be found.
For example, like CVE-2018-11237(https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11237), EXPLOIT-DB is referenced but the link is actually broken.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## rdb
### before
```console
$ go-exploitdb fetch exploitdb
$ go-exploitdb search --type CVE --param CVE-2018-11237
Failed to get OffensiveSecurity. DB relationship may be broken, use `$ go-exploitdb fetch exploitdb` to recreate DB. err: record not found
```

### after
```console
$ go-exploitdb fetch exploitdb
$ go-exploitdb search --type CVE --param CVE-2018-11237

Results: 
---------------------------------------

[*]CVE-ExploitID Reference:
  CVE: CVE-2018-11237
  Exploit Type: OffensiveSecurity
  Exploit Unique ID: 44750
  URL: https://www.exploit-db.com/exploits/44750
  Description: 

[*]Exploit Detail Info: 
  [*]OffensiveSecurity: ---------------------------------------
```

## redis
### before
```console
$ go-exploitdb fetch --dbtype redis --dbpath "redis://127.0.0.1:6379/1" exploitdb 
$ go-exploitdb search --dbtype redis --dbpath "redis://127.0.0.1:6379/1" --type CVE --param CVE-2018-11237

Results: 
---------------------------------------

[*]CVE-ExploitID Reference:
  CVE: CVE-2018-11237
  Exploit Type: OffensiveSecurity
  Exploit Unique ID: 44750
  URL: https://www.exploit-db.com/exploits/44750
  Description: 

[*]Exploit Detail Info: ---------------------------------------
```

### after
```console
$ go-exploitdb fetch --dbtype redis --dbpath "redis://127.0.0.1:6379/1" exploitdb 
$ go-exploitdb search --dbtype redis --dbpath "redis://127.0.0.1:6379/1" --type CVE --param CVE-2018-11237

Results: 
---------------------------------------

[*]CVE-ExploitID Reference:
  CVE: CVE-2018-11237
  Exploit Type: OffensiveSecurity
  Exploit Unique ID: 44750
  URL: https://www.exploit-db.com/exploits/44750
  Description: 

[*]Exploit Detail Info: 
  [*]OffensiveSecurity: ---------------------------------------
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

