### PR TITLE
feat(log) no progress when --log-json option

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -209,7 +210,12 @@ func (r *RDBDriver) deleteAndInsertExploit(exploitType models.ExploitType, explo
 
 	if len(oldIDs) > 0 {
 		log15.Info("Deleting old Exploits")
-		bar := pb.StartNew(len(oldIDs))
+		bar := pb.StartNew(len(oldIDs)).SetWriter(func() io.Writer {
+			if viper.GetBool("log-json") {
+				return io.Discard
+			}
+			return os.Stderr
+		}())
 		for idx := range chunkSlice(len(oldIDs), batchSize) {
 			osIDs := []models.OffensiveSecurity{}
 			if err := tx.Model(&models.OffensiveSecurity{}).Select("id").Where("exploit_id IN ?", oldIDs[idx.From:idx.To]).Find(&osIDs).Error; err != nil {
@@ -251,7 +257,12 @@ func (r *RDBDriver) deleteAndInsertExploit(exploitType models.ExploitType, explo
 	}
 
 	log15.Info("Inserting new Exploits")
-	bar := pb.StartNew(len(exploits))
+	bar := pb.StartNew(len(exploits)).SetWriter(func() io.Writer {
+		if viper.GetBool("log-json") {
+			return io.Discard
+		}
+		return os.Stderr
+	}())
 	for idx := range chunkSlice(len(exploits), batchSize) {
 		if err = tx.Create(exploits[idx.From:idx.To]).Error; err != nil {
 			return xerrors.Errorf("Failed to insert. err: %w", err)

--- a/db/redis.go
+++ b/db/redis.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 	"time"
 
@@ -324,7 +326,12 @@ func (r *RedisDriver) InsertExploit(exploitType models.ExploitType, exploits []m
 		return xerrors.Errorf("Failed to unmarshal JSON. err: %w", err)
 	}
 
-	bar := pb.StartNew(len(exploits))
+	bar := pb.StartNew(len(exploits)).SetWriter(func() io.Writer {
+		if viper.GetBool("log-json") {
+			return io.Discard
+		}
+		return os.Stderr
+	}())
 	var noCveIDExploitCount, cveIDExploitCount int
 	for idx := range chunkSlice(len(exploits), batchSize) {
 		pipe := r.conn.Pipeline()


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

no progress when --log-json option

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

## before
```console
$ go-exploitdb fetch exploitdb --log-json
{"lvl":"info","msg":"Fetching Offensive Security Exploit","t":"2024-07-04T16:27:30.396943139+09:00"}
{"URL":"https://cve.mitre.org/data/downloads/allitems-cvrf.xml","lvl":"info","msg":"Fetching","t":"2024-07-04T16:27:30.39725692+09:00"}
{"URL":"https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_exploits.csv","lvl":"info","msg":"Fetching","t":"2024-07-04T16:28:23.123808431+09:00"}
{"URL":"https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_shellcodes.csv","lvl":"info","msg":"Fetching","t":"2024-07-04T16:28:23.661596644+09:00"}
{"URL":"https://gitlab.com/exploit-database/exploitdb-papers/-/raw/main/files_papers.csv","lvl":"info","msg":"Fetching","t":"2024-07-04T16:28:24.060105586+09:00"}
{"URL":"https://gitlab.com/exploit-database/exploitdb/-/raw/main/ghdb.xml","lvl":"info","msg":"Fetching","t":"2024-07-04T16:28:24.402305658+09:00"}
{"count":60138,"lvl":"info","msg":"Offensive Security Exploit","t":"2024-07-04T16:28:25.116201178+09:00"}
{"db":"sqlite3","lvl":"info","msg":"Insert Exploit into go-exploitdb.","t":"2024-07-04T16:28:25.116312321+09:00"}
{"lvl":"info","msg":"Inserting 60138 Exploits","t":"2024-07-04T16:28:25.116334638+09:00"}
{"lvl":"info","msg":"Inserting new Exploits","t":"2024-07-04T16:28:25.179692747+09:00"}
60138 / 60138 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 6852 p/s
{"count":29206,"lvl":"info","msg":"No CveID Exploit Count","t":"2024-07-04T16:28:34.158326086+09:00"}
{"count":30932,"lvl":"info","msg":"CveID Exploit Count","t":"2024-07-04T16:28:34.158392725+09:00"}
```

## after
```console
$ go-exploitdb fetch exploitdb --log-json
{"lvl":"info","msg":"Fetching Offensive Security Exploit","t":"2024-07-04T16:29:26.164413081+09:00"}
{"URL":"https://cve.mitre.org/data/downloads/allitems-cvrf.xml","lvl":"info","msg":"Fetching","t":"2024-07-04T16:29:26.164525004+09:00"}
{"URL":"https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_exploits.csv","lvl":"info","msg":"Fetching","t":"2024-07-04T16:30:19.362401322+09:00"}
{"URL":"https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_shellcodes.csv","lvl":"info","msg":"Fetching","t":"2024-07-04T16:30:19.949999287+09:00"}
{"URL":"https://gitlab.com/exploit-database/exploitdb-papers/-/raw/main/files_papers.csv","lvl":"info","msg":"Fetching","t":"2024-07-04T16:30:20.37316689+09:00"}
{"URL":"https://gitlab.com/exploit-database/exploitdb/-/raw/main/ghdb.xml","lvl":"info","msg":"Fetching","t":"2024-07-04T16:30:20.715533578+09:00"}
{"count":60138,"lvl":"info","msg":"Offensive Security Exploit","t":"2024-07-04T16:30:21.356218238+09:00"}
{"db":"sqlite3","lvl":"info","msg":"Insert Exploit into go-exploitdb.","t":"2024-07-04T16:30:21.356261988+09:00"}
{"lvl":"info","msg":"Inserting 60138 Exploits","t":"2024-07-04T16:30:21.356271119+09:00"}
{"lvl":"info","msg":"Deleting old Exploits","t":"2024-07-04T16:30:21.400603542+09:00"}
{"lvl":"info","msg":"Inserting new Exploits","t":"2024-07-04T16:30:22.68531134+09:00"}
{"count":29206,"lvl":"info","msg":"No CveID Exploit Count","t":"2024-07-04T16:30:27.519650935+09:00"}
{"count":30932,"lvl":"info","msg":"CveID Exploit Count","t":"2024-07-04T16:30:27.519688127+09:00"}

$ go-exploitdb fetch exploitdb
INFO[07-04|16:31:23] Fetching Offensive Security Exploit 
INFO[07-04|16:31:23] Fetching                                 URL=https://cve.mitre.org/data/downloads/allitems-cvrf.xml
INFO[07-04|16:32:18] Fetching                                 URL=https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_exploits.csv
INFO[07-04|16:32:18] Fetching                                 URL=https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_shellcodes.csv
INFO[07-04|16:32:19] Fetching                                 URL=https://gitlab.com/exploit-database/exploitdb-papers/-/raw/main/files_papers.csv
INFO[07-04|16:32:19] Fetching                                 URL=https://gitlab.com/exploit-database/exploitdb/-/raw/main/ghdb.xml
INFO[07-04|16:32:20] Offensive Security Exploit               count=60138
INFO[07-04|16:32:20] Insert Exploit into go-exploitdb.        db=sqlite3
INFO[07-04|16:32:20] Inserting 60138 Exploits 
INFO[07-04|16:32:20] Deleting old Exploits 
60138 / 60138 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 53969 p/s
INFO[07-04|16:32:21] Inserting new Exploits 
60138 / 60138 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 13077 p/s
INFO[07-04|16:32:26] No CveID Exploit Count                   count=29206
INFO[07-04|16:32:26] CveID Exploit Count                      count=30932
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

