### PR TITLE
fix(fetcher/exploitdb): change from CVRF to CVE List v5

### DIFF
--- a/fetcher/exploitdb.go
+++ b/fetcher/exploitdb.go
@@ -1,18 +1,23 @@
 package fetcher
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/url"
 	"path"
+	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gocarina/gocsv"
 	"github.com/inconshreveable/log15"
-	"golang.org/x/net/html/charset"
 	"golang.org/x/xerrors"
 
 	"github.com/vulsio/go-exploitdb/models"
@@ -49,53 +54,67 @@ func FetchExploitDB() ([]models.Exploit, error) {
 	return joinExploits(toCVEs, toDocument, toShellCode, toPaper, toGHDB), nil
 }
 
-type cvrfdoc struct {
-	Vulnerability []struct {
-		CVE        string `xml:"CVE"`
-		References []struct {
-			URL         string `xml:"URL"`
-			Description string `xml:"Description"`
-		} `xml:"References>Reference"`
-	} `xml:"Vulnerability"`
+type cve struct {
+	CVEMetadata struct {
+		CVEID string `json:"cveId"`
+	} `json:"cveMetadata"`
+	Containers struct {
+		CNA struct {
+			References []struct {
+				Name *string  `json:"name,omitempty"`
+				Tags []string `json:"tags,omitempty"`
+				URL  string   `json:"url"`
+			} `json:"references,omitempty"`
+		} `json:"cna"`
+	} `json:"containers"`
 }
 
 func fetchExploitMitreCVE() (map[string][]string, error) {
-	url := "https://cve.mitre.org/data/downloads/allitems-cvrf.xml"
+	toCVEs := make(map[string][]string)
+
+	url := "https://github.com/CVEProject/cvelistV5/archive/refs/heads/main.tar.gz"
 	log15.Info("Fetching", "URL", url)
 	bs, err := util.FetchURL(url)
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
 
-	var root cvrfdoc
-	decoder := xml.NewDecoder(bytes.NewReader(bs))
-	decoder.CharsetReader = charset.NewReaderLabel
-	if err = decoder.Decode(&root); err != nil {
-		return nil, xerrors.Errorf("Failed to unmarshal. err: %w", err)
+	gr, err := gzip.NewReader(bytes.NewReader(bs))
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to create gzip reader. err: %w", err)
 	}
+	defer gr.Close()
 
-	toCVEs := map[string][]string{}
-	for _, e := range root.Vulnerability {
-		for _, r := range e.References {
-			if strings.HasPrefix(r.URL, "https://www.exploit-db.com/exploits/") {
-				eid := strings.TrimSuffix(strings.TrimPrefix(r.URL, "https://www.exploit-db.com/exploits/"), "/")
-				toCVEs[eid] = append(toCVEs[eid], e.CVE)
-				continue
-			}
-
-			refType, exploitID, ok := strings.Cut(r.Description, ":")
-			if !ok {
-				continue
-			}
-			// https://cve.mitre.org/data/refs/index.html
-			if refType != "EXPLOIT-DB" {
-				continue
-			}
-			if _, err := strconv.Atoi(exploitID); err != nil {
-				continue
-			}
-			toCVEs[exploitID] = append(toCVEs[exploitID], e.CVE)
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
 		}
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to next tar reader. err: %w", err)
+		}
+
+		if hdr.FileInfo().IsDir() {
+			continue
+		}
+
+		if !strings.HasPrefix(filepath.Base(hdr.Name), "CVE-") || filepath.Ext(hdr.Name) != ".json" {
+			continue
+		}
+
+		var v cve
+		if err := json.NewDecoder(tr).Decode(&v); err != nil {
+			return nil, xerrors.Errorf("Failed to decode json. err: %w", err)
+		}
+
+		for _, r := range v.Containers.CNA.References {
+			if !slices.Contains(r.Tags, "x_refsource_EXPLOIT-DB") {
+				continue
+			}
+			toCVEs[path.Base(r.URL)] = append(toCVEs[path.Base(r.URL)], v.CVEMetadata.CVEID)
+		}
+
 	}
 	return toCVEs, nil
 }


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes https://github.com/vulsio/go-exploitdb/actions/runs/17169071351/job/48715301631

```console
$ curl -I https://cve.mitre.org/data/downloads/allitems-cvrf.xml
HTTP/2 301 
server: CloudFront
date: Sat, 23 Aug 2025 05:09:05 GMT
content-length: 0
location: https://www.cve.org/Resources/Media/Archives/OldWebsite/index.html
x-cache: LambdaGeneratedResponse from cloudfront
via: 1.1 ba08db91a54adc603ccfe9c896341086.cloudfront.net (CloudFront)
x-amz-cf-pop: KIX50-P2
x-amz-cf-id: B6yCEgkO38CNQVAqNFpvYCuJ1PmBsfAemG2rZ0B3Psw5qASr-Qhpbg==
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

by Fetch CI

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

